### PR TITLE
avoid creating a temp dir and changing cwd there

### DIFF
--- a/human_eval/execution.py
+++ b/human_eval/execution.py
@@ -10,8 +10,7 @@ import signal
 import tempfile
 
 def unsafe_execute(problem, completion, result, timeout):
-
-    with create_tempdir():
+    if True:
 
         # These system calls are needed when cleaning up tempdir.
         import os


### PR DESCRIPTION
this makes all unit-tests work which use folder and files. 

Before merging this, we should mention that in the readme. Unit-tests should not modify folders; and/or clean up

closes #12 