### PR TITLE
add simeple image masking test case

### DIFF
--- a/test_cases/mask_image.ipynb
+++ b/test_cases/mask_image.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b27a1d0e-e184-425b-9944-0e354aad8b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mask_image(image, mask):\n",
+    "    \"\"\"\n",
+    "    Takes a 2D input image and a 2D binary mask image, then applies the mask to the input image and returns the result.\n",
+    "    \"\"\"\n",
+    "    import numpy as np\n",
+    "    image = np.asarray(image)\n",
+    "    mask = np.asarray(mask)\n",
+    "    return image * mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2243e607-8d2d-4a77-b612-64d8223d70db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "    \n",
+    "    image = [\n",
+    "        [2,2,2,2,2],\n",
+    "        [2,2,3,2,2],\n",
+    "        [2,3,3,3,2],\n",
+    "        [2,2,3,2,2],\n",
+    "        [2,2,2,2,2],\n",
+    "    ]\n",
+    "    mask = [\n",
+    "        [0,0,0,0,0],\n",
+    "        [0,0,1,0,0],\n",
+    "        [0,1,1,1,0],\n",
+    "        [0,0,1,0,0],\n",
+    "        [0,0,0,0,0],\n",
+    "    ]\n",
+    "    reference = [\n",
+    "        [0,0,0,0,0],\n",
+    "        [0,0,3,0,0],\n",
+    "        [0,3,3,3,0],\n",
+    "        [0,0,3,0,0],\n",
+    "        [0,0,0,0,0],\n",
+    "    ]\n",
+    "    masked_image = candidate(image,mask)\n",
+    "    assert np.array_equal(masked_image, reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "577fd3b1-aa81-40c0-8a27-88e86ba48718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(mask_image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d470d040-51c2-4b57-a8bd-82565c6e1642",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [X] a new test-case for the benchmark
  * [X] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- I have created a very simple image masking task.

How do you think will this influence the benchmark results?
- Not much, I think the problem is too easy

Why do you think it makes sense to merge this PR?
- I think it is a common base task to filter out, poor results



