### PR TITLE
fix typos in test-case names

### DIFF
--- a/test_cases/workflow_segmentation_counting.ipynb
+++ b/test_cases/workflow_segmentation_counting.ipynb
@@ -7,21 +7,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def worflow_segmentation_measurement_summary(image):\n",
+    "def workflow_segmentation_counting(image):\n",
     "    \"\"\"\n",
-    "    This function implements a workflow consisting of these steps:\n",
-    "    * threshold intensity input image using Otsu's method\n",
-    "    * label connected components\n",
-    "    * measure area of the labeled objects\n",
-    "    * determine mean area of all objects\n",
+    "    This function segments objects in an image with intensity above average \n",
+    "    and returns their count.\n",
     "    \"\"\"\n",
     "    import skimage\n",
     "    import numpy as np\n",
-    "    binary_image = image > skimage.filters.threshold_otsu(image)\n",
-    "    label_image = skimage.measure.label(binary_image)\n",
-    "    stats = skimage.measure.regionprops(label_image)\n",
-    "    areas = [s.area for s in stats]\n",
-    "    return np.mean(areas)"
+    "    average_intensity = np.asarray(image).mean()\n",
+    "    binary = image > average_intensity\n",
+    "    labels = skimage.measure.label(binary)\n",
+    "    return labels.max()"
    ]
   },
   {
@@ -34,29 +30,23 @@
     "def check(candidate):\n",
     "    import numpy as np\n",
     "    \n",
-    "    assert candidate(np.asarray([\n",
+    "    result = candidate(np.asarray([\n",
     "        [0,0,0,0,0],\n",
-    "        [1,1,1,0,0],\n",
-    "        [1,1,1,0,0],\n",
-    "        [1,1,0,0,0],\n",
+    "        [0,1,0,0,0],\n",
+    "        [0,0,0,2,0],\n",
+    "        [0,1,0,0,0],\n",
     "        [0,0,0,0,0],\n",
-    "    ])) == 8\n",
+    "    ])) \n",
+    "    assert result == 3\n",
     "\n",
-    "    assert candidate(np.asarray([\n",
-    "        [1,1,0,1,1],\n",
-    "        [1,1,0,0,0],\n",
-    "        [0,0,0,1,1],\n",
-    "        [1,1,0,1,1],\n",
+    "    result = candidate(np.asarray([\n",
     "        [0,0,0,0,0],\n",
-    "    ])) == 3\n",
-    "\n",
-    "    assert candidate(np.asarray([\n",
+    "        [0,100,0,90,0],\n",
     "        [0,0,0,0,0],\n",
-    "        [0,1,0,1,0],\n",
+    "        [0,110,0,80,0],\n",
     "        [0,0,0,0,0],\n",
-    "        [0,0,1,0,0],\n",
-    "        [0,0,0,0,0],\n",
-    "    ])) == 1"
+    "    ])) \n",
+    "    assert result == 4"
    ]
   },
   {
@@ -66,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check(worflow_segmentation_measurement_summary)"
+    "check(workflow_segmentation_counting)"
    ]
   },
   {

--- a/test_cases/workflow_segmentation_measurement_summary.ipynb
+++ b/test_cases/workflow_segmentation_measurement_summary.ipynb
@@ -7,17 +7,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def worflow_segmentation_counting(image):\n",
+    "def workflow_segmentation_measurement_summary(image):\n",
     "    \"\"\"\n",
-    "    This function segments objects in an image with intensity above average \n",
-    "    and returns their count.\n",
+    "    This function implements a workflow consisting of these steps:\n",
+    "    * threshold intensity input image using Otsu's method\n",
+    "    * label connected components\n",
+    "    * measure area of the labeled objects\n",
+    "    * determine mean area of all objects\n",
     "    \"\"\"\n",
     "    import skimage\n",
     "    import numpy as np\n",
-    "    average_intensity = np.asarray(image).mean()\n",
-    "    binary = image > average_intensity\n",
-    "    labels = skimage.measure.label(binary)\n",
-    "    return labels.max()"
+    "    binary_image = image > skimage.filters.threshold_otsu(image)\n",
+    "    label_image = skimage.measure.label(binary_image)\n",
+    "    stats = skimage.measure.regionprops(label_image)\n",
+    "    areas = [s.area for s in stats]\n",
+    "    return np.mean(areas)"
    ]
   },
   {
@@ -30,23 +34,29 @@
     "def check(candidate):\n",
     "    import numpy as np\n",
     "    \n",
-    "    result = candidate(np.asarray([\n",
+    "    assert candidate(np.asarray([\n",
     "        [0,0,0,0,0],\n",
-    "        [0,1,0,0,0],\n",
-    "        [0,0,0,2,0],\n",
-    "        [0,1,0,0,0],\n",
+    "        [1,1,1,0,0],\n",
+    "        [1,1,1,0,0],\n",
+    "        [1,1,0,0,0],\n",
     "        [0,0,0,0,0],\n",
-    "    ])) \n",
-    "    assert result == 3\n",
+    "    ])) == 8\n",
     "\n",
-    "    result = candidate(np.asarray([\n",
+    "    assert candidate(np.asarray([\n",
+    "        [1,1,0,1,1],\n",
+    "        [1,1,0,0,0],\n",
+    "        [0,0,0,1,1],\n",
+    "        [1,1,0,1,1],\n",
     "        [0,0,0,0,0],\n",
-    "        [0,100,0,90,0],\n",
+    "    ])) == 3\n",
+    "\n",
+    "    assert candidate(np.asarray([\n",
     "        [0,0,0,0,0],\n",
-    "        [0,110,0,80,0],\n",
+    "        [0,1,0,1,0],\n",
     "        [0,0,0,0,0],\n",
-    "    ])) \n",
-    "    assert result == 4"
+    "        [0,0,1,0,0],\n",
+    "        [0,0,0,0,0],\n",
+    "    ])) == 1"
    ]
   },
   {
@@ -56,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check(worflow_segmentation_counting)"
+    "check(workflow_segmentation_measurement_summary)"
    ]
   },
   {

--- a/test_cases/workflow_watershed_segmentation_correction_measurement.ipynb
+++ b/test_cases/workflow_watershed_segmentation_correction_measurement.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def worflow_watershed_segmentation_correction_measurement(image):\n",
+    "def workflow_watershed_segmentation_correction_measurement(image):\n",
     "    \"\"\"\n",
     "    This function implements a workflow consisting of these steps:\n",
     "    * blurs the image a bit\n",
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check(worflow_watershed_segmentation_correction_measurement)"
+    "check(workflow_watershed_segmentation_correction_measurement)"
    ]
   },
   {


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [x] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- I'm renaming some test-cases because they had typos in their names

How do you think will this influence the benchmark results?
- Not.

Why do you think it makes sense to merge this PR?
- We may never be typo-free, but this PR is a good step in the right direction.



