### PR TITLE
add bland-altman test case

### DIFF
--- a/test_cases/bland_altman.ipynb
+++ b/test_cases/bland_altman.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b27a1d0e-e184-425b-9944-0e354aad8b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bland_altman(dataframe, column1:str, column2:str):\n",
+    "    \"\"\"\n",
+    "    Takes two specified columns from a given dataframe and applies Bland-Altman-Analysis to them.\n",
+    "    Therefore, it adds two new columns, one called 'mean' containing the mean of the two corresponding values,\n",
+    "    and one called 'diff' containing the difference between the two.\n",
+    "    \"\"\"\n",
+    "    import scipy\n",
+    "    data1 = dataframe[column1]\n",
+    "    data2 = dataframe[column2]\n",
+    "    dataframe['mean'] = (data1 + data2) / 2\n",
+    "    dataframe['diff'] = data2 - data1\n",
+    "    return dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2243e607-8d2d-4a77-b612-64d8223d70db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import pandas as pd\n",
+    "    import numpy as np\n",
+    "    df = pd.DataFrame(\n",
+    "        {\n",
+    "         'a':[1,2,3,0],\n",
+    "         'b':[2,2,3,6]\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "    candidate(df, 'a', 'b')\n",
+    "\n",
+    "    assert len(df.columns) == 4\n",
+    "    \n",
+    "    mean_column = df['mean']\n",
+    "    diff_column = df['diff']\n",
+    "    \n",
+    "    assert np.array_equal([1.5, 2, 3, 3], mean_column)\n",
+    "    assert np.array_equal([1,  0,0, 6], diff_column) or \\\n",
+    "           np.array_equal([-1, 0,0,-6], diff_column)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "577fd3b1-aa81-40c0-8a27-88e86ba48718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(bland_altman)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d470d040-51c2-4b57-a8bd-82565c6e1642",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [x] a new test-case for the benchmark
  * [x] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- This adds  a test-case for applying Bland-Altman analysis
- As we cannot test if a plot is drawn correctly, we cannot test the Bland-Altman plot.

How do you think will this influence the benchmark results?
- This is a relatively easy test-case. I presume that most LLMs should be able to solve it.

Why do you think it makes sense to merge this PR?
- Bland-Altman-plots are a useful tool for visualizing differences between methods. As we cannot test plotting tools, this is the minimum we can do in this context.



