### PR TITLE
count assert statements in our test-case notebooks

### DIFF
--- a/demo/count_asserts.ipynb
+++ b/demo/count_asserts.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c72bf085-47aa-47ad-a268-c7802e3e1323",
+   "metadata": {},
+   "source": [
+    "# Counting assert-statements\n",
+    "\n",
+    "\n",
+    "In order to provide a number of unit-tests per test-case, we could count the number of `assert` statements in our code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9d222de3-8624-4fbc-a15a-5c67974b8c47",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average number of \"assert\" per .ipynb file: 2.4791666666666665\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "def count_asserts_in_ipynb(folder_path):\n",
+    "    # List all files in the provided folder\n",
+    "    files = os.listdir(folder_path)\n",
+    "    \n",
+    "    # Filter for .ipynb files\n",
+    "    ipynb_files = [file for file in files if file.endswith('.ipynb')]\n",
+    "    \n",
+    "    total_assert_count = 0\n",
+    "    ipynb_file_count = 0\n",
+    "    \n",
+    "    # Go through each .ipynb file\n",
+    "    for file in ipynb_files:\n",
+    "        path = os.path.join(folder_path, file)\n",
+    "        \n",
+    "        # Open and read the file\n",
+    "        with open(path, 'r', encoding='utf-8') as f:\n",
+    "            content = f.read()\n",
+    "            \n",
+    "        # Count occurrences of \"assert\"\n",
+    "        assert_count = content.count('assert')\n",
+    "        total_assert_count += assert_count\n",
+    "        ipynb_file_count += 1\n",
+    "    \n",
+    "    # Avoid division by zero\n",
+    "    if ipynb_file_count > 0:\n",
+    "        # Calculate average\n",
+    "        average_asserts = total_assert_count / ipynb_file_count\n",
+    "        print(f'Average number of \"assert\" per .ipynb file: {average_asserts}')\n",
+    "    else:\n",
+    "        print('No .ipynb files found in the directory.')\n",
+    "\n",
+    "# Replace 'your_folder_path_here' with the actual folder path\n",
+    "count_asserts_in_ipynb('../test_cases/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5dab002-3273-4dab-93f5-bf46626fd3ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [x] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- This delivers a way for estimating the number of unit-tests per test-case. We're counting the actual `assert` statements which test our functions.

How do you think will this influence the benchmark results?
- It adds another metric that tells us something about the quantity of the tests.

Why do you think it makes sense to merge this PR?
- I'm not sure if we need it. The original HumanEval paper mentions approx 7.7 unit tests per test-case. We have approx 2.5 assert statements per test-case... I'm not sure if these are comparable...

