### PR TITLE
Add test for radial intensity profile

### DIFF
--- a/test_cases/radial_intensity_profile.ipynb
+++ b/test_cases/radial_intensity_profile.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 1,
    "id": "62a24ee3-b70a-4d9f-8a1e-8878cae835ec",
    "metadata": {},
    "outputs": [],
@@ -16,6 +16,7 @@
     "    Output:\n",
     "    - an array containing the average intensities\n",
     "    \"\"\"\n",
+    "    import numpy as np\n",
     "    y, x = np.indices((image.shape))\n",
     "    r = np.sqrt((x - xc)**2 + (y - yc)**2)\n",
     "    r = r.astype(int)\n",
@@ -27,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 2,
    "id": "c26195ec-50f8-4465-b312-fa40b5e3ae08",
    "metadata": {},
    "outputs": [],
@@ -46,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 3,
    "id": "55fdf71d-d03c-4919-9765-0a27e27fd737",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This PR contains:
* [X] a new test-case for the benchmark
  * [X] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #34

Short description:
- Adds a test for computing a radial intensity profile in a 2D image

How do you think will this influence the benchmark results?
- Not sure, chatGPT 4.0 got it right at the first go

Why do you think it makes sense to merge this PR?
- Radial intensity profiles are frequently needed in BIA

Notes:
- I looked for how to implement this [on this website](https://stackoverflow.com/questions/21242011/most-efficient-way-to-calculate-radial-profile), and then, once I was finished, I was curious as to what chatGPT4.0 would suggest, and I found it interesting that it literally suggested the solution mentioned on this website.



