### PR TITLE
add dependencies which made some tests fail

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -127,6 +127,7 @@ dependencies:
       - pandocfilters==1.5.1
       - parso==0.8.4
       - partd==1.4.1
+      - patsy==0.5.6
       - pillow==10.3.0
       - platformdirs==4.2.0
       - prometheus-client==0.20.0
@@ -168,6 +169,7 @@ dependencies:
       - sniffio==1.3.1
       - soupsieve==2.5
       - stack-data==0.6.3
+      - statsmodels==0.14.1
       - termcolor==2.4.0
       - terminado==0.18.1
       - threadpoolctl==3.4.0
@@ -193,6 +195,7 @@ dependencies:
       - webcolors==1.13
       - webencodings==0.5.1
       - websocket-client==1.7.0
+      - xarray==2024.3.0
       - zarr==2.17.2
       - zipp==3.18.1
 prefix: C:\Users\haase\mambaforge\envs\heb

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ umap-learn
 dask
 zarr
 circle-fit
+statsmodels
+xarray
+pillow


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [x] new dependencies to requirement.txt
  * [x] The environment.yml files updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [x] bug fixes 

Related github issue (if relevant): #39 #41 #42 

Short description:
- Here I'm proposing to add some requirements (pillow, statsmodels and xarray)
- I'm proposing them because they were detected in #42 and presumably made tests fail in former evaluations.

How do you think will this influence the benchmark results?
- I have not tested, but this may make more tests pass. LLM-generated code may have been functional, but we didn't have those dependencies installed.

Why do you think it makes sense to merge this PR?
- All three added libraries are common tools for bio-image analysts. It makes sense that LLMs want to use them and thus, it makes sense to add them.



