### PR TITLE
add contributing guide and code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,77 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project lead robert.haase@tu-dresden.de. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to the human-eval-bia project
+
+Welcome to this page and great to see you are considering to contribute to this project. 
+Please note that we have a [code of conduct](CODE-OF-CONDUCT.md) in this project. 
+Please follow it to make this a happy community project.
+
+Contributions like feedback, suggestions, notebooks, code, data and pull-requests are very welcome.
+It is recommended to open a [github issue](https://github.com/haesleinhuepf/human-eval-bia/issues) 
+to discuss things first and make a plan before you spend time and send a pull-request that later cannot be merged because of misunderstandings.
+
+## Aim and scope of this benchmark / test-case collection
+
+We aim at collecting test-cases for benchmarking LLMs for Bio-Image Analysis code generation as wide as possible, but limited to that research field.
+Before considering to contribute, please check the following criteria, which serve as guide what we will merge and what not:
+
+We accept:
+* new simple or complex tasks commonly done by bio-image analysts
+* tasks that can be from any common workflow step in image processing, segmentation, feature extraction, tabular data wranging, statistics, dimensionality reduction, clustering
+* tasks that involve multiple example image files or folder (see example_data folder)
+* tricky multi-step workflows are explicitly welcome, also if workflow designers suspect that no LLM can solve them at this point.
+* tasks for processing imaging modalities such as brightfield microscopy, fluorescence microscopy, electron microscopy, histology/histopathology are welcome
+* functional correctness should be evaluated on simple (small) example data, ideally data in the example_data folder is reused
+
+We may not accept:
+* new imaging modalities that are not commonly referred to as bio-image analysis (e.g. medical imaging, CT, MRI, astronomy, material science EM)
+* new requirements that do not run on common computers or require specific hardware (e.g. CUDA)
+* new files in the example_data folder that are larger than few megabytes
+* new test-cases that need long run-time (approx > 0.3 seconds)
+
+Out of scope pull-requests are
+
+## Project organization / management
+
+The project is currently maintained and lead by the [benevolent dictator](http://oss-watch.ac.uk/resources/benevolentdictatorgovernancemodel) 
+[@haesleinhuepf](https://github.com/haesleinhuepf) who is also open to sharing responsibities. 
+If you want to contribute or even become part of the decision making process, please get in touch. 
+Everyone is welcome who supports the major aims listed above.
+
+## How contributions become part of the collection
+
+After you submitted a pull-request, it will be reviewed and checked if the conditions above are met. 
+We may ask for minor changes and have a discussion about content. We aim at keeping this process short and not wasting anyone's time. 
+In case your materials are merged, and your contribution is more than just minor corrections and additions, you will be listed under authors and copyright holders, e.g. in the [LICENSE](LICENSE) file. 
+If your affiliation / institution should also be mentioned there, please include this as suggestion in your pull-request.
+
+## Copyright
+
+All contents of this repository are licensed [MIT](LICENSE) by the [authors and contributors](https://github.com/haesleinhuepf/human-eval-bia/contributors), unless mentioned otherwise.
+Please make sure your contribution can be shared under the same conditions.
+
+## Changes to these conditions
+
+These conditions may be changed by the maintainers any time. Nothing is nailed in stone. We have to write this to be on the safe side.
+If you contributed to the repository earlier and later you are unhappy about your contribution for whatever reasons, 
+please send a pull-request removing your contributions. We will accept this pull-request.


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [x] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #44 

Short description:
- Here I'm adding two documents: The CONTRIBUTING guide explains what pull-requests we are looking forward, and how the merge-process works. The code-of-conduct is a standard document reminding people to communicate kindly.

How do you think will this influence the benchmark results?
- Not.

Why do you think it makes sense to merge this PR?
- These documents may increase the likelyhood that people consider contributing to our benchmark.



