### PR TITLE
rename read-... test case to open-... so that it fits better to others

### DIFF
--- a/test_cases/open_zarr.ipynb
+++ b/test_cases/open_zarr.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def read_zarr_array(zarr_file_location):\n",
+    "def open_zarr(zarr_file_location):\n",
     "    \"\"\"\n",
     "    Opens a zarr file and returns the array\n",
     "    \"\"\"\n",
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check(read_zarr_array)"
+    "check(open_zarr)"
    ]
   },
   {


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [x] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- I'm just renaming a test-case so that all test cases which open files, are close by each other in the list.

How do you think will this influence the benchmark results?
- Not

Why do you think it makes sense to merge this PR?
- Just for clarity, I'm trying to unify test-case names a little bit.



