### PR TITLE
Add test for linear intensity profile

### DIFF
--- a/test_cases/linear_intensity_profile.ipynb
+++ b/test_cases/linear_intensity_profile.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "de95e58a-b0c8-4275-b866-bee213592ddf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def linear_intensity_profile(image, x1, y1, x2, y2):\n",
+    "    \"\"\"\n",
+    "    Computes the intensity profile along a line in an image\n",
+    "    Inputs:\n",
+    "    - image: 2D numpy array\n",
+    "    - x1, y1: coordinates of the first point\n",
+    "    - x2, y2: coordinates of the second point\n",
+    "    Output:\n",
+    "    - an array containing the intensities along the line\n",
+    "    \"\"\"\n",
+    "    #import statements\n",
+    "    import numpy as np\n",
+    "\n",
+    "    #line length (euclidean distance) (to account for rounding +1)\n",
+    "    length = int(np.sqrt((x2 - x1)**2 + (y2 - y1)**2)) + 1 \n",
+    "\n",
+    "    #evenly spaced line coordinates in x and y\n",
+    "    x = np.linspace(x1, x2, length)\n",
+    "    y = np.linspace(y1, y2, length)\n",
+    "\n",
+    "    #filter out points outside the image boundaries\n",
+    "    valid_indices = (x >= 0) & (x < image.shape[1]) & (y >= 0) & (y < image.shape[0])\n",
+    "\n",
+    "    #extract intensities for valid indices\n",
+    "    intensities = image[y[valid_indices].astype(int), x[valid_indices].astype(int)]\n",
+    "    \n",
+    "    return intensities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "17df6e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "    image = np.array([[1, 2, 3],\n",
+    "                      [4, 5, 6],\n",
+    "                      [7, 8, 9]])\n",
+    "    x1, y1 = 0, 1\n",
+    "    x2, y2 = 2, 1\n",
+    "    expected_output = np.array([4, 5, 6])\n",
+    "    assert np.array_equal(candidate(image, x1, y1, x2, y2), expected_output)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "6ec71762",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(linear_intensity_profile)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/linear_intensity_profile.ipynb
+++ b/test_cases/linear_intensity_profile.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 65,
    "id": "de95e58a-b0c8-4275-b866-bee213592ddf",
    "metadata": {},
    "outputs": [],
@@ -28,17 +28,17 @@
     "    y = np.linspace(y1, y2, length)\n",
     "\n",
     "    #filter out points outside the image boundaries\n",
-    "    valid_indices = (x >= 0) & (x < image.shape[1]) & (y >= 0) & (y < image.shape[0])\n",
+    "    filtered_indices = (x >= 0) & (x < image.shape[1]) & (y >= 0) & (y < image.shape[0])\n",
     "\n",
     "    #extract intensities for valid indices\n",
-    "    intensities = image[y[valid_indices].astype(int), x[valid_indices].astype(int)]\n",
+    "    intensities = image[y[filtered_indices].astype(int), x[filtered_indices].astype(int)]\n",
     "    \n",
     "    return intensities"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 66,
    "id": "17df6e1f",
    "metadata": {},
    "outputs": [],
@@ -47,22 +47,31 @@
     "    import numpy as np\n",
     "    image = np.array([[1, 2, 3],\n",
     "                      [4, 5, 6],\n",
-    "                      [7, 8, 9]])\n",
-    "    x1, y1 = 0, 1\n",
-    "    x2, y2 = 2, 1\n",
-    "    expected_output = np.array([4, 5, 6])\n",
-    "    assert np.array_equal(candidate(image, x1, y1, x2, y2), expected_output)"
+    "                      [7, 8, 9],\n",
+    "                      [10, 11, 12]])\n",
+    "    x1, y1 = 0, 0\n",
+    "    x2, y2 = 2, 2\n",
+    "    reference = np.array([1, 5, 9])\n",
+    "    assert np.array_equal(candidate(image, x1, y1, x2, y2), reference)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
-   "id": "6ec71762",
+   "execution_count": 67,
+   "id": "dd3cf020-17fb-4e0b-b0b3-cfcd6c0d40f1",
    "metadata": {},
    "outputs": [],
    "source": [
     "check(linear_intensity_profile)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7b3689d-f6aa-47d7-b2fe-ab8e067e2bfa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- ...

How do you think will this influence the benchmark results?
- ...

Why do you think it makes sense to merge this PR?
- ...


This PR is intended to fix Issue #36. I am also happy to make adjustment, for example I think also the function ´skimage.measure.profile_line()´ could be used.

Best,
Mara


