### PR TITLE
Linear intensity profile

### DIFF
--- a/test_cases/linear_intensity_profile.ipynb
+++ b/test_cases/linear_intensity_profile.ipynb
@@ -8,6 +8,15 @@
    "outputs": [],
    "source": [
     "def linear_intensity_profile(image, starting_point, ending_point):\n",
+    "    '''\n",
+    "    Computes the intensity profile along a line in an image,\n",
+    "    Inputs:\n",
+    "    - image: 2D numpy array\n",
+    "    - starting_point: x and y coordinates of the first point,\n",
+    "    - ending_point: x and y coordinates of the second point\n",
+    "    Output:\n",
+    "    - an array containing the intensities along the line\n",
+    "    '''\n",
     "    from skimage.measure import profile_line\n",
     "    return profile_line(image, starting_point, ending_point)"
    ]

--- a/test_cases/linear_intensity_profile.ipynb
+++ b/test_cases/linear_intensity_profile.ipynb
@@ -1,75 +1,67 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "8b8b2dc9-66e4-4cf1-ac1d-0b621c184a59",
-   "metadata": {},
-   "source": [
-    "- input: image, and two point coordinates\n",
-    "- ouput: intensity along the line as array or list"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "7a4ddce0-b11d-4770-972d-6be87bfdc559",
    "metadata": {},
    "outputs": [],
    "source": [
     "def linear_intensity_profile(image, starting_point, ending_point):\n",
     "    from skimage.measure import profile_line\n",
-    "    return skimage.measure.profile_line(image, starting_point, ending_point)"
+    "    return profile_line(image, starting_point, ending_point)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "c0ced31c-c8c7-4d31-a119-c7a905c35af0",
+   "execution_count": 2,
+   "id": "b7e75f82-ad58-4cde-8660-085c466082ee",
    "metadata": {},
    "outputs": [],
    "source": [
     "def check(candidate):\n",
+    "    # import \n",
     "    import numpy as np\n",
-    "    image = np.array([[1, 1, 4],\n",
-    "                      [5, 7, 9],\n",
-    "                      [4, 2, 0]])\n",
-    "    starting_point = 0,0\n",
-    "    ending_point = 2,2\n",
-    "    reference = np.array([1, 7, 0])\n",
-    "    assert np.array_equal(candidate(image, starting_point, ending_point), reference)"
+    "\n",
+    "    # image\n",
+    "    image = np.array([[0, 1, 3, 8, 6],\n",
+    "                      [9, 3, 4, 9, 1],\n",
+    "                      [1, 4, 5, 2, 2],\n",
+    "                      [0, 1, 1, 5, 6],\n",
+    "                      [2, 1, 4, 1, 1]])\n",
+    "\n",
+    "    # horizontal line \n",
+    "    start_horizontal = 1, 1\n",
+    "    end_horizontal = 1, 4\n",
+    "    reference_horizontal = np.array([3, 4, 9, 1])\n",
+    "\n",
+    "    # vertical line\n",
+    "    start_vertical = 0, 4\n",
+    "    end_vertical = 4, 4\n",
+    "    reference_vertical = np.array([6, 1, 2, 6, 1])\n",
+    "\n",
+    "    # diagonal line\n",
+    "    start_diagonal = 0, 0\n",
+    "    end_diagonal = 4, 4\n",
+    "    reference_diagonal = np.array([0., 4., 4., 5., 3., 4., 1.])\n",
+    "    # comment: the profile_line function interpolates pixel values at those coordinates using linear interpolation\n",
+    "    # therefore it uses in this case (0,0), (0.8, 0.8), (1.6, 1.6), (2.4, 2.4), (3.2, 3.2), (4, 4)\n",
+    "\n",
+    "    # assert\n",
+    "    assert np.array_equal(candidate(image, start_horizontal, end_horizontal), reference_horizontal)\n",
+    "    assert np.array_equal(candidate(image, start_vertical, end_vertical), reference_vertical)\n",
+    "    assert np.array_equal(candidate(image, start_diagonal, end_diagonal), reference_diagonal)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "316e928c-67c7-47e8-9b4e-f7258fb45f60",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'skimage' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[6], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlinear_intensity_profile\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[5], line 9\u001b[0m, in \u001b[0;36mcheck\u001b[0;34m(candidate)\u001b[0m\n\u001b[1;32m      7\u001b[0m ending_point \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m2\u001b[39m,\u001b[38;5;241m2\u001b[39m\n\u001b[1;32m      8\u001b[0m reference \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray([\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m7\u001b[39m, \u001b[38;5;241m0\u001b[39m])\n\u001b[0;32m----> 9\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39marray_equal(\u001b[43mcandidate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimage\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstarting_point\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mending_point\u001b[49m\u001b[43m)\u001b[49m, reference)\n",
-      "Cell \u001b[0;32mIn[4], line 3\u001b[0m, in \u001b[0;36mlinear_intensity_profile\u001b[0;34m(image, starting_point, ending_point)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mlinear_intensity_profile\u001b[39m(image, starting_point, ending_point):\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mskimage\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mmeasure\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m profile_line\n\u001b[0;32m----> 3\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mskimage\u001b[49m\u001b[38;5;241m.\u001b[39mmeasure\u001b[38;5;241m.\u001b[39mprofile_line(image, starting_point, ending_point)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'skimage' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "check(linear_intensity_profile)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "035cb96a-c415-4fbf-9606-6e06460eb2fd",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -88,7 +80,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/test_cases/linear_intensity_profile.ipynb
+++ b/test_cases/linear_intensity_profile.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8b8b2dc9-66e4-4cf1-ac1d-0b621c184a59",
+   "metadata": {},
+   "source": [
+    "- input: image, and two point coordinates\n",
+    "- ouput: intensity along the line as array or list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7a4ddce0-b11d-4770-972d-6be87bfdc559",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def linear_intensity_profile(image, starting_point, ending_point):\n",
+    "    from skimage.measure import profile_line\n",
+    "    return skimage.measure.profile_line(image, starting_point, ending_point)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c0ced31c-c8c7-4d31-a119-c7a905c35af0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "    image = np.array([[1, 1, 4],\n",
+    "                      [5, 7, 9],\n",
+    "                      [4, 2, 0]])\n",
+    "    starting_point = 0,0\n",
+    "    ending_point = 2,2\n",
+    "    reference = np.array([1, 7, 0])\n",
+    "    assert np.array_equal(candidate(image, starting_point, ending_point), reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "316e928c-67c7-47e8-9b4e-f7258fb45f60",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'skimage' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlinear_intensity_profile\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[5], line 9\u001b[0m, in \u001b[0;36mcheck\u001b[0;34m(candidate)\u001b[0m\n\u001b[1;32m      7\u001b[0m ending_point \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m2\u001b[39m,\u001b[38;5;241m2\u001b[39m\n\u001b[1;32m      8\u001b[0m reference \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39marray([\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m7\u001b[39m, \u001b[38;5;241m0\u001b[39m])\n\u001b[0;32m----> 9\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m np\u001b[38;5;241m.\u001b[39marray_equal(\u001b[43mcandidate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mimage\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstarting_point\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mending_point\u001b[49m\u001b[43m)\u001b[49m, reference)\n",
+      "Cell \u001b[0;32mIn[4], line 3\u001b[0m, in \u001b[0;36mlinear_intensity_profile\u001b[0;34m(image, starting_point, ending_point)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mlinear_intensity_profile\u001b[39m(image, starting_point, ending_point):\n\u001b[1;32m      2\u001b[0m     \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mskimage\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mmeasure\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m profile_line\n\u001b[0;32m----> 3\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mskimage\u001b[49m\u001b[38;5;241m.\u001b[39mmeasure\u001b[38;5;241m.\u001b[39mprofile_line(image, starting_point, ending_point)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'skimage' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "check(linear_intensity_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "035cb96a-c415-4fbf-9606-6e06460eb2fd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [x] a new test-case for the benchmark
  * [x] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #36 

Short description:
- adds a test for linear intensity profile in 2D
-  this test case makes use of the function `profile_line` available under `skimage.measure`
   - input: image, and two point coordinates
   - ouput: intensity along the line as array
- when checking the candidate, it checks a horizontal, a vertical and a diagonal line

How do you think will this influence the benchmark results?
- should be a relatively simple problem

Why do you think it makes sense to merge this PR?
- Linear intensity profiles are frequently needed in BIA