### PR TITLE
Add `local_maxima_from_distance_transform`, `flow_field_deformation`, and `detect_ellipse` test cases

### DIFF
--- a/test_cases/detect_ellipse.ipynb
+++ b/test_cases/detect_ellipse.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-05T01:10:15.502690Z",
+     "start_time": "2024-08-05T01:10:15.499956Z"
+    }
+   },
+   "source": [
+    "def detect_ellipse(image):\n",
+    "    \"\"\"\n",
+    "    Given a binary edge map, detect the ellipse in the image using a Hough Transform.\n",
+    "    Return the center of the ellipse in the image as a tuple (y, x).\n",
+    "    \"\"\"\n",
+    "    from skimage.transform import hough_ellipse\n",
+    "    result = hough_ellipse(image,  accuracy=5, threshold=10)\n",
+    "    result.sort(order='accumulator')\n",
+    "    \n",
+    "    # Estimated parameters for the ellipse\n",
+    "    best = list(result[-1])\n",
+    "    yc, xc, a, b = (int(round(x)) for x in best[1:5])\n",
+    "    \n",
+    "    return yc, xc"
+   ],
+   "outputs": [],
+   "execution_count": 87
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-05T01:10:25.140024Z",
+     "start_time": "2024-08-05T01:10:25.137211Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "    from skimage.draw import ellipse_perimeter\n",
+    "\n",
+    "    image = np.zeros((100, 100))\n",
+    "    cy, cx = ellipse_perimeter(30, 60, 20, 10, np.pi / 4)\n",
+    "    image[cy, cx] = 1\n",
+    "    yc, xc = detect_ellipse(image)\n",
+    "    \n",
+    "    dx = yc - 30\n",
+    "    dy = xc - 60\n",
+    "    \n",
+    "    # Check if the center of the ellipse is detected within a distance of 7 pixels\n",
+    "    assert dx ** 2 + dy ** 2 < 7 ** 2"
+   ],
+   "id": "3bf4caa996b0604f",
+   "outputs": [],
+   "execution_count": 90
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-05T01:10:25.722761Z",
+     "start_time": "2024-08-05T01:10:25.658436Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "check(detect_ellipse)",
+   "id": "9ff01af9981e8577",
+   "outputs": [],
+   "execution_count": 91
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "11d154fa92a96406"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/detect_ellipse.ipynb
+++ b/test_cases/detect_ellipse.ipynb
@@ -2,14 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "initial_id",
    "metadata": {
-    "collapsed": true,
     "ExecuteTime": {
      "end_time": "2024-08-05T01:10:15.502690Z",
      "start_time": "2024-08-05T01:10:15.499956Z"
     }
    },
+   "outputs": [],
    "source": [
     "def detect_ellipse(image):\n",
     "    \"\"\"\n",
@@ -25,77 +26,90 @@
     "    yc, xc, a, b = (int(round(x)) for x in best[1:5])\n",
     "    \n",
     "    return yc, xc"
-   ],
-   "outputs": [],
-   "execution_count": 87
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3bf4caa996b0604f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-05T01:10:25.140024Z",
      "start_time": "2024-08-05T01:10:25.137211Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
-    "def check(candidate):\n",
-    "    import numpy as np\n",
+    "import numpy as np\n",
+    "def draw_elipse(x, y, a=20, b=10, angle_rad=np.pi / 4):\n",
     "    from skimage.draw import ellipse_perimeter\n",
-    "\n",
     "    image = np.zeros((100, 100))\n",
-    "    cy, cx = ellipse_perimeter(30, 60, 20, 10, np.pi / 4)\n",
+    "    cy, cx = ellipse_perimeter(y, x, a, b, angle_rad)\n",
     "    image[cy, cx] = 1\n",
+    "    return image\n",
+    "\n",
+    "def check(candidate):\n",
+    "\n",
+    "    x = 60\n",
+    "    y = 30\n",
+    "    image = draw_elipse(x=x, y=y)\n",
     "    yc, xc = detect_ellipse(image)\n",
     "    \n",
-    "    dx = yc - 30\n",
-    "    dy = xc - 60\n",
+    "    # Check if the center of the ellipse is detected within a distance of 1 pixel\n",
+    "    assert abs(yc - y) <= 1\n",
+    "    assert abs(xc - x) <= 1\n",
+    "\n",
+    "    x = 25\n",
+    "    y = 12\n",
+    "    image = draw_elipse(x=x, y=y, a=5, b=3)\n",
+    "    yc, xc = detect_ellipse(image)\n",
     "    \n",
-    "    # Check if the center of the ellipse is detected within a distance of 7 pixels\n",
-    "    assert dx ** 2 + dy ** 2 < 7 ** 2"
-   ],
-   "id": "3bf4caa996b0604f",
-   "outputs": [],
-   "execution_count": 90
+    "    # Check if the center of the ellipse is detected within a distance of 1 pixel\n",
+    "    assert abs(yc - y) <= 1\n",
+    "    assert abs(xc - x) <= 1\n"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9ff01af9981e8577",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-05T01:10:25.722761Z",
      "start_time": "2024-08-05T01:10:25.658436Z"
     }
    },
-   "cell_type": "code",
-   "source": "check(detect_ellipse)",
-   "id": "9ff01af9981e8577",
    "outputs": [],
-   "execution_count": 91
+   "source": [
+    "check(detect_ellipse)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "",
-   "id": "11d154fa92a96406"
+   "id": "11d154fa92a96406",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/test_cases/flow_field_deformation.ipynb
+++ b/test_cases/flow_field_deformation.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-05T00:17:25.858246Z",
+     "start_time": "2024-08-05T00:17:25.855338Z"
+    }
+   },
+   "source": [
+    "def flow_field_deformation(flow_field, target):\n",
+    "    \"\"\"\n",
+    "    Given a flow_field (H, W, 2) in which every pixel represents the relative displacement\n",
+    "    vector to its position, then apply the deformation to the target (N, W) image and return\n",
+    "    the deformed image.\n",
+    "    \"\"\"\n",
+    "    import SimpleITK as sitk\n",
+    "\n",
+    "    target = sitk.GetImageFromArray(target)\n",
+    "\n",
+    "    displacement = sitk.DisplacementFieldTransform(2)\n",
+    "    field_size = list(flow_field.shape[:2])\n",
+    "    field_origin = [0, 0]\n",
+    "    field_spacing = [1.0, 1.0]\n",
+    "    field_direction = [1, 0, 0, 1]  # direction cosine matrix (row major order)\n",
+    "\n",
+    "    # Concatenate all the information into a single list\n",
+    "    displacement.SetFixedParameters(\n",
+    "        field_size + field_origin + field_spacing + field_direction\n",
+    "    )\n",
+    "    # Set the interpolator to nearest neighbor\n",
+    "    displacement.SetInterpolator(sitk.sitkNearestNeighbor)\n",
+    "\n",
+    "    originalDisplacements = flow_field.reshape((-1, 2)).flatten()\n",
+    "    displacement.SetParameters(originalDisplacements)\n",
+    "\n",
+    "    resampler = sitk.ResampleImageFilter()\n",
+    "    resampler.SetTransform(displacement)\n",
+    "    resampler.SetReferenceImage(target)\n",
+    "    resampled = resampler.Execute(target)\n",
+    "\n",
+    "    return sitk.GetArrayFromImage(resampled)"
+   ],
+   "outputs": [],
+   "execution_count": 34
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-05T00:17:26.563612Z",
+     "start_time": "2024-08-05T00:17:26.560788Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "\n",
+    "    flow_field = np.zeros((5, 5, 2))\n",
+    "    flow_field[3, 2] = [-1, -1]\n",
+    "\n",
+    "    image = np.arange(25).reshape((5, 5))\n",
+    "\n",
+    "    result = candidate(flow_field, image)\n",
+    "\n",
+    "    assert result[3, 2] == result[2, 1]"
+   ],
+   "id": "3bf4caa996b0604f",
+   "outputs": [],
+   "execution_count": 35
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-05T00:17:27.035824Z",
+     "start_time": "2024-08-05T00:17:27.031473Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "check(flow_field_deformation)",
+   "id": "9ff01af9981e8577",
+   "outputs": [],
+   "execution_count": 36
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "94e88b818cb19c06"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/flow_field_deformation.ipynb
+++ b/test_cases/flow_field_deformation.ipynb
@@ -2,20 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "initial_id",
    "metadata": {
-    "collapsed": true,
     "ExecuteTime": {
      "end_time": "2024-08-05T00:17:25.858246Z",
      "start_time": "2024-08-05T00:17:25.855338Z"
     }
    },
+   "outputs": [],
    "source": [
     "def flow_field_deformation(flow_field, target):\n",
     "    \"\"\"\n",
-    "    Given a flow_field (H, W, 2) in which every pixel represents the relative displacement\n",
-    "    vector to its position, then apply the deformation to the target (N, W) image and return\n",
-    "    the deformed image.\n",
+    "    Given a vector field `flow_field` (H, W, 2) in which every pixel represents the relative \n",
+    "    displacement vector to its position, then apply the deformation to the target (N, W) \n",
+    "    image and return the deformed image.\n",
     "    \"\"\"\n",
     "    import SimpleITK as sitk\n",
     "\n",
@@ -43,18 +44,19 @@
     "    resampled = resampler.Execute(target)\n",
     "\n",
     "    return sitk.GetArrayFromImage(resampled)"
-   ],
-   "outputs": [],
-   "execution_count": 34
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3bf4caa996b0604f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-05T00:17:26.563612Z",
      "start_time": "2024-08-05T00:17:26.560788Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "def check(candidate):\n",
     "    import numpy as np\n",
@@ -63,54 +65,52 @@
     "    flow_field[3, 2] = [-1, -1]\n",
     "\n",
     "    image = np.arange(25).reshape((5, 5))\n",
-    "\n",
     "    result = candidate(flow_field, image)\n",
-    "\n",
+    "    \n",
     "    assert result[3, 2] == result[2, 1]"
-   ],
-   "id": "3bf4caa996b0604f",
-   "outputs": [],
-   "execution_count": 35
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9ff01af9981e8577",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-05T00:17:27.035824Z",
      "start_time": "2024-08-05T00:17:27.031473Z"
     }
    },
-   "cell_type": "code",
-   "source": "check(flow_field_deformation)",
-   "id": "9ff01af9981e8577",
    "outputs": [],
-   "execution_count": 36
+   "source": [
+    "check(flow_field_deformation)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "",
-   "id": "94e88b818cb19c06"
+   "id": "94e88b818cb19c06",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/test_cases/local_maxima_from_distance_transform.ipynb
+++ b/test_cases/local_maxima_from_distance_transform.ipynb
@@ -2,20 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "initial_id",
    "metadata": {
-    "collapsed": true,
     "ExecuteTime": {
      "end_time": "2024-08-04T03:20:46.529021Z",
      "start_time": "2024-08-04T03:20:46.523232Z"
     }
    },
+   "outputs": [],
    "source": [
     "def local_maxima_from_distance_transform(binary_image, nms_window):\n",
     "    \"\"\"\n",
     "    Takes a binary_image and computes the distance transform of the image. \n",
     "    Then, it finds the local maxima of the distance transform image and returns their coordinates.\n",
     "    The local maxima are filtered by a non-maximum suppression window of size nms_window.\n",
+    "    The function returns the y,x coordinates as list.\n",
     "    \"\"\"\n",
     "    import scipy.ndimage as ndi\n",
     "    import skimage.feature as skf\n",
@@ -30,19 +32,20 @@
     "    \n",
     "    local_maxima = skf.peak_local_max(image_max)\n",
     "\n",
-    "    return local_maxima"
-   ],
-   "outputs": [],
-   "execution_count": 1
+    "    return local_maxima.tolist()"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "405bf41c9d5b21f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-04T03:20:48.018285Z",
      "start_time": "2024-08-04T03:20:48.015012Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "def check(candidate):\n",
     "    import numpy as np\n",
@@ -58,13 +61,13 @@
     "        [0, 0, 1, 0, 0],\n",
     "    ]), 0)\n",
     "\n",
-    "    result = set([tuple(x) for x in result.tolist()])\n",
+    "    result = set([tuple(x) for x in result])\n",
     "\n",
     "    reference = {(2, 2), (5, 2)}\n",
     "    \n",
-    "    \n",
     "    # compare the results\n",
-    "    assert reference == result\n",
+    "    for r in reference:\n",
+    "        assert r in result\n",
     "    \n",
     "    \n",
     "    # Test 1: with non-maximum suppression window\n",
@@ -78,55 +81,54 @@
     "        [0, 0, 1, 0, 0],\n",
     "    ]), 7)\n",
     "    \n",
-    "    result = set([tuple(x) for x in result.tolist()])\n",
+    "    result = set([tuple(x) for x in result])\n",
     "    \n",
     "    reference = {(2, 2)}\n",
     "\n",
     "    assert reference == result"
-   ],
-   "id": "405bf41c9d5b21f",
-   "outputs": [],
-   "execution_count": 2
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e6762a676c3b49c9",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-04T03:20:49.806548Z",
      "start_time": "2024-08-04T03:20:49.153278Z"
     }
    },
-   "cell_type": "code",
-   "source": "check(local_maxima_from_distance_transform)",
-   "id": "e6762a676c3b49c9",
    "outputs": [],
-   "execution_count": 3
+   "source": [
+    "check(local_maxima_from_distance_transform)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": "",
-   "id": "51689a4125fa315b"
+   "id": "51689a4125fa315b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/test_cases/local_maxima_from_distance_transform.ipynb
+++ b/test_cases/local_maxima_from_distance_transform.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T03:20:46.529021Z",
+     "start_time": "2024-08-04T03:20:46.523232Z"
+    }
+   },
+   "source": [
+    "def local_maxima_from_distance_transform(binary_image, nms_window):\n",
+    "    \"\"\"\n",
+    "    Takes a binary_image and computes the distance transform of the image. \n",
+    "    Then, it finds the local maxima of the distance transform image and returns their coordinates.\n",
+    "    The local maxima are filtered by a non-maximum suppression window of size nms_window.\n",
+    "    \"\"\"\n",
+    "    import scipy.ndimage as ndi\n",
+    "    import skimage.feature as skf\n",
+    "    \n",
+    "    distance_transform = ndi.distance_transform_edt(binary_image)\n",
+    "    \n",
+    "    image_max = ndi.maximum_filter(distance_transform, size=nms_window, mode='constant')\n",
+    "    \n",
+    "    # suppress non-maxima values by setting them to -1\n",
+    "    mask = distance_transform == image_max\n",
+    "    image_max[~mask] = -1\n",
+    "    \n",
+    "    local_maxima = skf.peak_local_max(image_max)\n",
+    "\n",
+    "    return local_maxima"
+   ],
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-04T03:20:48.018285Z",
+     "start_time": "2024-08-04T03:20:48.015012Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "\n",
+    "    # Test 1: no non-maximum suppression\n",
+    "    result = candidate(np.asarray([\n",
+    "        [0, 0, 0, 0, 0],\n",
+    "        [0, 1, 1, 1, 0],\n",
+    "        [0, 1, 1, 1, 0],\n",
+    "        [0, 1, 1, 1, 0],\n",
+    "        [0, 0, 1, 0, 0],\n",
+    "        [0, 1, 1, 1, 1],\n",
+    "        [0, 0, 1, 0, 0],\n",
+    "    ]), 0)\n",
+    "\n",
+    "    result = set([tuple(x) for x in result.tolist()])\n",
+    "\n",
+    "    reference = {(2, 2), (5, 2)}\n",
+    "    \n",
+    "    \n",
+    "    # compare the results\n",
+    "    assert reference == result\n",
+    "    \n",
+    "    \n",
+    "    # Test 1: with non-maximum suppression window\n",
+    "    result = candidate(np.asarray([\n",
+    "        [0, 0, 0, 0, 0],\n",
+    "        [0, 1, 1, 1, 0],\n",
+    "        [0, 1, 1, 1, 0],\n",
+    "        [0, 1, 1, 1, 0],\n",
+    "        [0, 0, 1, 0, 0],\n",
+    "        [0, 1, 1, 1, 1],\n",
+    "        [0, 0, 1, 0, 0],\n",
+    "    ]), 7)\n",
+    "    \n",
+    "    result = set([tuple(x) for x in result.tolist()])\n",
+    "    \n",
+    "    reference = {(2, 2)}\n",
+    "\n",
+    "    assert reference == result"
+   ],
+   "id": "405bf41c9d5b21f",
+   "outputs": [],
+   "execution_count": 2
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-04T03:20:49.806548Z",
+     "start_time": "2024-08-04T03:20:49.153278Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "check(local_maxima_from_distance_transform)",
+   "id": "e6762a676c3b49c9",
+   "outputs": [],
+   "execution_count": 3
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "51689a4125fa315b"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [x] a new test-case for the benchmark
  * [x] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Short description:
- This PR presents three new test cases: a local maxima detector from a Euclidean distance transform on a binary image, an image deformation based on a flow field, and an ellipse detector using the Hough transform. 

How do you think will this influence the benchmark results?
- Those tests require knowledge of specific functions on well-established Python libraries. Considering that LLMs are trained on GitHub codes and possibly web-scraped documentation, those tests will assess the LLM capabilities of abstraction to fit user-specific needs for code generation on bioimage analysis. 

Why do you think it makes sense to merge this PR?
- The three test cases relate to bioimage analysis algorithms. The first one is useful for detecting possible cell centers in a region according to the farthest pixels from its border and possibly filtering close centers.  The second relates to deformable registration and asks to apply the dense registration map to a new image. Lastly, the third test detects an ellipse in an image, which can be used as a rudimentary way of detecting an elliptical-shaped cell. 
