### PR TITLE
Adding test case for selecting cells that co-express some gene (image intensity)

### DIFF
--- a/test_cases/remove_labels_on_edges.ipynb
+++ b/test_cases/remove_labels_on_edges.ipynb
@@ -74,7 +74,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/test_cases/remove_small_labels.ipynb
+++ b/test_cases/remove_small_labels.ipynb
@@ -79,7 +79,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/test_cases/select_coexpressing_cells.ipynb
+++ b/test_cases/select_coexpressing_cells.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "6d51b7a1-93fc-469d-b9bd-529d42fc4f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def select_coexpressing_cells(image, labels, threshold):\n",
+    "    \"\"\"\n",
+    "    Selects and returns the subset of cell segments from labels (HxW)\n",
+    "    that co expresses the total intensity of all channels above a\n",
+    "    certain threshold given an input image (HxWxC)\n",
+    "    \"\"\"\n",
+    "    import numpy as np\n",
+    "    import pandas as pd\n",
+    "    from skimage.measure import regionprops_table\n",
+    "\n",
+    "    df = pd.DataFrame(\n",
+    "        regionprops_table(labels, image, properties=(\"label\", \"area\", \"intensity_mean\"))\n",
+    "    )\n",
+    "    mean_cols = [c for c in df.columns if c.startswith(\"intensity_mean\")]\n",
+    "    sum_cols = [f\"intensity_sum-{i}\" for i in range(len(mean_cols))]\n",
+    "    \n",
+    "    df[sum_cols] = df[mean_cols] * df[\"area\"].to_numpy()\n",
+    "    \n",
+    "    selected_ids = df.loc[(df[sum_cols] > threshold).all(axis=1), \"label\"].to_numpy()\n",
+    "    \n",
+    "    below_threshold_mask = np.isin(labels, selected_ids, invert=False)\n",
+    "    filtered_labels = labels * below_threshold_mask\n",
+    "\n",
+    "    return filtered_labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "1bbb1ced-3949-4836-9700-b8563a676927",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "\n",
+    "    labels = np.asarray([[0, 1, 1],\n",
+    "                         [2, 2, 3],\n",
+    "                         [0, 0, 3]])\n",
+    "\n",
+    "    image = np.asarray([[[0, 0, 0], [5, 2, 6], [5, 2, 4]],\n",
+    "                        [[10,5, 3], [0, 5, 7], [1, 4, 4]],\n",
+    "                        [[0, 0, 0], [0, 0, 0], [4, 4, 4]]])\n",
+    "\n",
+    "    expected_labels = np.asarray([[0, 0, 0],\n",
+    "                                  [2, 2, 0],\n",
+    "                                  [0, 0, 0]])\n",
+    "\n",
+    "    results = candidate(image, labels, 7)\n",
+    "\n",
+    "    np.testing.assert_equal(expected_labels, results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "e08f95a4-0f4a-4ed9-9edb-c5ee19155746",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "\nArrays are not equal\n\nMismatched elements: 2 / 9 (22.2%)\nMax absolute difference: 2\nMax relative difference: inf\n x: array([[0, 0, 0],\n       [2, 2, 0],\n       [0, 0, 0]])\n y: array([[0, 0, 0],\n       [0, 0, 0],\n       [0, 0, 0]])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[81], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[43mselect_coexpressing_cells\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[80], line 18\u001b[0m, in \u001b[0;36mcheck\u001b[0;34m(candidate)\u001b[0m\n\u001b[1;32m     12\u001b[0m expected_labels \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39masarray([[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m     13\u001b[0m                               [\u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m     14\u001b[0m                               [\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m]])\n\u001b[1;32m     16\u001b[0m results \u001b[38;5;241m=\u001b[39m candidate(image, labels, \u001b[38;5;241m7\u001b[39m)\n\u001b[0;32m---> 18\u001b[0m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtesting\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mexpected_labels\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mresults\u001b[49m\u001b[43m)\u001b[49m\n",
+      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ultrack/lib/python3.10/contextlib.py:79\u001b[0m, in \u001b[0;36mContextDecorator.__call__.<locals>.inner\u001b[0;34m(*args, **kwds)\u001b[0m\n\u001b[1;32m     76\u001b[0m \u001b[38;5;129m@wraps\u001b[39m(func)\n\u001b[1;32m     77\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21minner\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwds):\n\u001b[1;32m     78\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_recreate_cm():\n\u001b[0;32m---> 79\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/mambaforge/envs/ultrack/lib/python3.10/site-packages/numpy/testing/_private/utils.py:862\u001b[0m, in \u001b[0;36massert_array_compare\u001b[0;34m(comparison, x, y, err_msg, verbose, header, precision, equal_nan, equal_inf, strict)\u001b[0m\n\u001b[1;32m    858\u001b[0m         err_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(remarks)\n\u001b[1;32m    859\u001b[0m         msg \u001b[38;5;241m=\u001b[39m build_err_msg([ox, oy], err_msg,\n\u001b[1;32m    860\u001b[0m                             verbose\u001b[38;5;241m=\u001b[39mverbose, header\u001b[38;5;241m=\u001b[39mheader,\n\u001b[1;32m    861\u001b[0m                             names\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mx\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m), precision\u001b[38;5;241m=\u001b[39mprecision)\n\u001b[0;32m--> 862\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAssertionError\u001b[39;00m(msg)\n\u001b[1;32m    863\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[1;32m    864\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtraceback\u001b[39;00m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: \nArrays are not equal\n\nMismatched elements: 2 / 9 (22.2%)\nMax absolute difference: 2\nMax relative difference: inf\n x: array([[0, 0, 0],\n       [2, 2, 0],\n       [0, 0, 0]])\n y: array([[0, 0, 0],\n       [0, 0, 0],\n       [0, 0, 0]])"
+     ]
+    }
+   ],
+   "source": [
+    "check(select_coexpressing_cells)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/select_coexpressing_cells.ipynb
+++ b/test_cases/select_coexpressing_cells.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 1,
    "id": "6d51b7a1-93fc-469d-b9bd-529d42fc4f6b",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 2,
    "id": "1bbb1ced-3949-4836-9700-b8563a676927",
    "metadata": {},
    "outputs": [],
@@ -62,26 +62,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 3,
    "id": "e08f95a4-0f4a-4ed9-9edb-c5ee19155746",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "\nArrays are not equal\n\nMismatched elements: 2 / 9 (22.2%)\nMax absolute difference: 2\nMax relative difference: inf\n x: array([[0, 0, 0],\n       [2, 2, 0],\n       [0, 0, 0]])\n y: array([[0, 0, 0],\n       [0, 0, 0],\n       [0, 0, 0]])",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[81], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[43mselect_coexpressing_cells\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[80], line 18\u001b[0m, in \u001b[0;36mcheck\u001b[0;34m(candidate)\u001b[0m\n\u001b[1;32m     12\u001b[0m expected_labels \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39masarray([[\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m     13\u001b[0m                               [\u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m0\u001b[39m],\n\u001b[1;32m     14\u001b[0m                               [\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m]])\n\u001b[1;32m     16\u001b[0m results \u001b[38;5;241m=\u001b[39m candidate(image, labels, \u001b[38;5;241m7\u001b[39m)\n\u001b[0;32m---> 18\u001b[0m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtesting\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mexpected_labels\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mresults\u001b[49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
-      "File \u001b[0;32m~/mambaforge/envs/ultrack/lib/python3.10/contextlib.py:79\u001b[0m, in \u001b[0;36mContextDecorator.__call__.<locals>.inner\u001b[0;34m(*args, **kwds)\u001b[0m\n\u001b[1;32m     76\u001b[0m \u001b[38;5;129m@wraps\u001b[39m(func)\n\u001b[1;32m     77\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21minner\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwds):\n\u001b[1;32m     78\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_recreate_cm():\n\u001b[0;32m---> 79\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/mambaforge/envs/ultrack/lib/python3.10/site-packages/numpy/testing/_private/utils.py:862\u001b[0m, in \u001b[0;36massert_array_compare\u001b[0;34m(comparison, x, y, err_msg, verbose, header, precision, equal_nan, equal_inf, strict)\u001b[0m\n\u001b[1;32m    858\u001b[0m         err_msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(remarks)\n\u001b[1;32m    859\u001b[0m         msg \u001b[38;5;241m=\u001b[39m build_err_msg([ox, oy], err_msg,\n\u001b[1;32m    860\u001b[0m                             verbose\u001b[38;5;241m=\u001b[39mverbose, header\u001b[38;5;241m=\u001b[39mheader,\n\u001b[1;32m    861\u001b[0m                             names\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mx\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124my\u001b[39m\u001b[38;5;124m'\u001b[39m), precision\u001b[38;5;241m=\u001b[39mprecision)\n\u001b[0;32m--> 862\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAssertionError\u001b[39;00m(msg)\n\u001b[1;32m    863\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m:\n\u001b[1;32m    864\u001b[0m     \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mtraceback\u001b[39;00m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: \nArrays are not equal\n\nMismatched elements: 2 / 9 (22.2%)\nMax absolute difference: 2\nMax relative difference: inf\n x: array([[0, 0, 0],\n       [2, 2, 0],\n       [0, 0, 0]])\n y: array([[0, 0, 0],\n       [0, 0, 0],\n       [0, 0, 0]])"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "check(select_coexpressing_cells)"
    ]

--- a/test_cases/select_coexpressing_cells.ipynb
+++ b/test_cases/select_coexpressing_cells.ipynb
@@ -7,9 +7,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def select_coexpressing_cells(image, labels, threshold):\n",
+    "def select_coexpressing_cells(image, label_image, threshold):\n",
     "    \"\"\"\n",
-    "    Selects and returns the subset of cell segments from labels (HxW)\n",
+    "    Selects and returns the subset of cell segments from a label_image\n",
     "    that co expresses the total intensity of all channels above a\n",
     "    certain threshold given an input image (HxWxC)\n",
     "    \"\"\"\n",
@@ -18,7 +18,7 @@
     "    from skimage.measure import regionprops_table\n",
     "\n",
     "    df = pd.DataFrame(\n",
-    "        regionprops_table(labels, image, properties=(\"label\", \"area\", \"intensity_mean\"))\n",
+    "        regionprops_table(label_image, image, properties=(\"label\", \"area\", \"intensity_mean\"))\n",
     "    )\n",
     "    mean_cols = [c for c in df.columns if c.startswith(\"intensity_mean\")]\n",
     "    sum_cols = [f\"intensity_sum-{i}\" for i in range(len(mean_cols))]\n",
@@ -27,8 +27,8 @@
     "    \n",
     "    selected_ids = df.loc[(df[sum_cols] > threshold).all(axis=1), \"label\"].to_numpy()\n",
     "    \n",
-    "    below_threshold_mask = np.isin(labels, selected_ids, invert=False)\n",
-    "    filtered_labels = labels * below_threshold_mask\n",
+    "    below_threshold_mask = np.isin(label_image, selected_ids, invert=False)\n",
+    "    filtered_labels = label_image * below_threshold_mask\n",
     "\n",
     "    return filtered_labels"
    ]
@@ -69,6 +69,14 @@
    "source": [
     "check(select_coexpressing_cells)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99ae1343-de77-4657-9ea0-4f5d01b122ff",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -87,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR contains:
* [X] a new test-case for the benchmark
  * [X] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 


Short description:
- This PR adds a new test case of a common task for bio-image analysts.

How do you think this will influence the benchmark results?
- While finding segments (cells) that co-express some gene given their fluorescence marker is a standard procedure, it requires knowledge of processing in data frames and images, which is often not obvious to non-programmers. 
- It requires combining multiple columns from a pandas data frame.
- So, I think this will be a challenging test case.

Why do you think it makes sense to merge this PR?
- It improves the test cases.

@haesleinhuepf, do you prefer a single PR or a PR per test?
