### PR TITLE
Add new test to register 3D timelapses

### DIFF
--- a/test_cases/register_timelapse.ipynb
+++ b/test_cases/register_timelapse.ipynb
@@ -81,6 +81,14 @@
    "source": [
     "check(register_timelapse)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b5e6c1e-2cbb-4f88-a2f3-8d2ce6b9347f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -99,7 +107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/test_cases/register_timelapse.ipynb
+++ b/test_cases/register_timelapse.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "305b0353-c0c8-4563-a504-eaa15210b963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def register_timelapse(video):\n",
+    "    \"\"\"\n",
+    "    Registers with subpixel precision a 3D timelapse (T,Z,Y,X) using translations in Z, Y, X.\n",
+    "    The last frame is the reference frame, and it remains fixed.\n",
+    "    \"\"\"\n",
+    "    from skimage import registration\n",
+    "    import scipy.ndimage as ndi\n",
+    "\n",
+    "    new_video = video.copy()\n",
+    "    ref_frame = new_video[-1]\n",
+    "    for t in range(len(video) - 1, 0, -1):\n",
+    "        mov_frame = video[t - 1]\n",
+    "        shift, _, _ = registration.phase_cross_correlation(\n",
+    "            ref_frame,\n",
+    "            mov_frame,\n",
+    "            upsample_factor=4,\n",
+    "            normalization=None,\n",
+    "        )\n",
+    "        # replaces old ref_frame with shifted mov_frame\n",
+    "        ref_frame = ndi.shift(mov_frame, shift, order=1)\n",
+    "        new_video[t - 1] = ref_frame\n",
+    "\n",
+    "    return new_video"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7cb3ee53-dcf8-4bd7-a953-a77920962187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "    from skimage.feature import peak_local_max\n",
+    "    shape = (15, 15, 15)\n",
+    "    \n",
+    "    def _gaussian(mean):\n",
+    "        variance = 0.5\n",
+    "\n",
+    "        support = np.stack(np.meshgrid(*[\n",
+    "            np.linspace(-s // 2, s // 2, s) + m\n",
+    "            for s, m in zip(shape, mean)\n",
+    "        ], indexing=\"ij\"))\n",
+    "\n",
+    "        density = np.exp(-np.linalg.norm(support, axis=0) / (2 * variance))\n",
+    "        return density\n",
+    "\n",
+    "    video = np.stack([\n",
+    "        _gaussian((-3, 3, 0)),\n",
+    "        _gaussian((2, 0, -2)),\n",
+    "        _gaussian((0, 2, 0))\n",
+    "    ])\n",
+    "        \n",
+    "    ref_coord = peak_local_max(video[-1])\n",
+    "    res_coords = np.concatenate([\n",
+    "        peak_local_max(frame)\n",
+    "        for frame in candidate(video)\n",
+    "        # for frame in video  # sanity check making sure original video doesn't pass test\n",
+    "    ])\n",
+    "\n",
+    "    max_dist = np.abs(res_coords - ref_coord)\n",
+    "    np.testing.assert_array_less(max_dist, 0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "abaa2554-8a00-4cfd-b12c-fdd67b415c0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(register_timelapse)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/register_timelapse.ipynb
+++ b/test_cases/register_timelapse.ipynb
@@ -9,8 +9,9 @@
    "source": [
     "def register_timelapse(video):\n",
     "    \"\"\"\n",
-    "    Registers with subpixel precision a 3D timelapse (T,Z,Y,X) using translations in Z, Y, X.\n",
+    "    Register a 3D timelapse (T,Z,Y,X) with subpixel precision using translations in Z, Y, X.\n",
     "    The last frame is the reference frame, and it remains fixed.\n",
+    "    The entire registered time-lapse is returned.\n",
     "    \"\"\"\n",
     "    from skimage import registration\n",
     "    import scipy.ndimage as ndi\n",


### PR DESCRIPTION
This PR contains:
* [X] a new test-case for the benchmark
  * [X] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- This PR implements a new test case of registration of a 3D timelapse. The catch is that the volumes need to be consistent not only between frames but also as a whole from beginning to end.

How do you think will this influence the benchmark results?
This is a very common procedure, and it should frequently be available online, but it is non-trivial due to the compounding of the frame's movement, so I think it will be a challenging test case.

Why do you think it makes sense to merge this PR?
- Adds a new test case that's routinely used when tracking or quantifying information over time in bio-image analysis workflows.
