### PR TITLE
Added FFT spectrum testcase. It is a hard one :-)

### DIFF
--- a/test_cases/fft_spectrum.ipynb
+++ b/test_cases/fft_spectrum.ipynb
@@ -2,12 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-13T14:54:50.960087Z",
      "start_time": "2024-08-13T14:54:50.953818Z"
     }
    },
+   "outputs": [],
    "source": [
     "\n",
     "def fft_spectrum(nd_image, padding):\n",
@@ -43,18 +45,18 @@
     "    magnitude_spectrum = np.log1p(np.abs(image_fft_shifted))\n",
     "        \n",
     "    return(magnitude_spectrum)"
-   ],
-   "outputs": [],
-   "execution_count": 87
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-13T14:54:51.702025Z",
      "start_time": "2024-08-13T14:54:51.695371Z"
     }
    },
+   "outputs": [],
    "source": [
     "def check(candidate):\n",
     "    \n",
@@ -107,25 +109,27 @@
     "    magnitude_spectrum_reference = fft_spectrum_reference(image, padding_width)\n",
     "    \n",
     "    assert np.allclose(magnitude_spectrum_candidate, magnitude_spectrum_reference)"
-   ],
-   "outputs": [],
-   "execution_count": 88
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-08-13T14:54:52.036029Z",
      "start_time": "2024-08-13T14:54:52.031560Z"
     }
    },
-   "source": "check(fft_spectrum)",
    "outputs": [],
-   "execution_count": 89
+   "source": [
+    "check(fft_spectrum)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# # display the magnitude spectrum of a 3D image:\n",
     "# import numpy as np\n",
@@ -159,9 +163,7 @@
     "# viewer.show\n",
     "    \n",
     "    "
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {

--- a/test_cases/fft_spectrum.ipynb
+++ b/test_cases/fft_spectrum.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-13T06:48:27.495893Z",
+     "start_time": "2024-08-13T06:48:27.490346Z"
+    }
+   },
+   "source": [
+    "\n",
+    "def fft_spectrum(nd_image, padding):\n",
+    "    \"\"\"\n",
+    "    Returns the FFT spectrum of an arbitrary nD image as the absolute logarithm (log1p) of the Fourier transform magnitude. Ensures that the DC component is at the center of the image. Uses reflection padding (provided as integer parameter) and Hamming apodisation to reduce artefacts due to discontinuities at the image borders.\n",
+    "    \"\"\"\n",
+    "    import numpy as np\n",
+    "\n",
+    "    # computing padding tuple:\n",
+    "    pad_width = ((padding, padding),)*nd_image.ndim\n",
+    "\n",
+    "    # Padding:\n",
+    "    image_padded = np.pad(nd_image, pad_width=pad_width, mode='symmetric')\n",
+    "    \n",
+    "    # prepare the apodisation window in 1D:\n",
+    "    from scipy import signal\n",
+    "    window_tuple = (signal.windows.hamming(length+2*padding) for length in nd_image.shape)\n",
+    "    \n",
+    "    # prepare the apodisation window in nD:\n",
+    "    import functools\n",
+    "    window = functools.reduce(np.multiply.outer, window_tuple)\n",
+    "    \n",
+    "    # Apodise:\n",
+    "    image_padded_apodised = window*image_padded\n",
+    "\n",
+    "    # Compute the Fourier transform of the image:\n",
+    "    image_fft = np.fft.fftn(image_padded_apodised)\n",
+    "    \n",
+    "    # Shift the zero-frequency component to the center of the spectrum:\n",
+    "    image_fft_shifted = np.fft.fftshift(image_fft)\n",
+    "    \n",
+    "    # Compute the magnitude spectrum:\n",
+    "    magnitude_spectrum = np.log1p(np.abs(image_fft_shifted))\n",
+    "        \n",
+    "    return(magnitude_spectrum)"
+   ],
+   "outputs": [],
+   "execution_count": 77
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-13T06:48:28.400202Z",
+     "start_time": "2024-08-13T06:48:28.396661Z"
+    }
+   },
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np   \n",
+    "\n",
+    "    # Test image:\n",
+    "    image = np.ones((5, 6, 7), dtype=np.int16)\n",
+    "\n",
+    "    # Padding:\n",
+    "    padding_width = 10\n",
+    "\n",
+    "    # running the candidate function:\n",
+    "    magnitude_spectrum_candidate = candidate(image, padding_width)\n",
+    "    \n",
+    "    # Reference implementation:\n",
+    "    magnitude_spectrum_reference = fft_spectrum(image, padding_width)\n",
+    "    \n",
+    "    assert np.array_equal(magnitude_spectrum_candidate, magnitude_spectrum_reference)"
+   ],
+   "outputs": [],
+   "execution_count": 78
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-08-13T06:48:29.827529Z",
+     "start_time": "2024-08-13T06:48:29.821646Z"
+    }
+   },
+   "source": "check(fft_spectrum)",
+   "outputs": [],
+   "execution_count": 79
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# # display the magnitude spectrum of a 3D image:\n",
+    "# import numpy as np\n",
+    "# import matplotlib.pyplot as plt\n",
+    "# \n",
+    "# # Camera Test image:\n",
+    "# image = np.ones((50, 50, 50), dtype=np.int16)\n",
+    "# \n",
+    "# # Fill the image with integer noise:\n",
+    "# image += np.random.randint(0, 10, image.shape)\n",
+    "# \n",
+    "# # Blurr the image:\n",
+    "# from scipy.ndimage import gaussian_filter\n",
+    "# image = gaussian_filter(image, sigma=12)\n",
+    "# \n",
+    "# # Padding:\n",
+    "# padding_width = 25\n",
+    "# \n",
+    "# # Compute the magnitude spectrum:\n",
+    "# magnitude_spectrum = fft_spectrum(image, padding_width)\n",
+    "# \n",
+    "# # Display the magnitude spectrum:\n",
+    "# #plt.imshow(magnitude_spectrum[15, :, :])\n",
+    "# #plt.show()\n",
+    "# \n",
+    "# # Display the magnitude spectrum in napari\n",
+    "# import napari\n",
+    "# viewer = napari.Viewer()\n",
+    "# viewer.add_image(magnitude_spectrum, name='Magnitude Spectrum')\n",
+    "# viewer.add_image(image, name='Original Image')\n",
+    "# viewer.show\n",
+    "    \n",
+    "    "
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test_cases/fft_spectrum.ipynb
+++ b/test_cases/fft_spectrum.ipynb
@@ -4,8 +4,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-13T14:51:53.135214Z",
-     "start_time": "2024-08-13T14:51:53.130031Z"
+     "end_time": "2024-08-13T14:54:50.960087Z",
+     "start_time": "2024-08-13T14:54:50.953818Z"
     }
    },
    "source": [
@@ -22,19 +22,19 @@
     "    # Padding:\n",
     "    image_padded = np.pad(nd_image, pad_width=pad_width, mode='symmetric')\n",
     "    \n",
-    "    # prepare the apodisation window in 1D:\n",
+    "    # prepare the apodization window in 1D:\n",
     "    from scipy import signal\n",
     "    window_tuple = (signal.windows.hamming(length+2*padding) for length in nd_image.shape)\n",
     "    \n",
-    "    # prepare the apodisation window in nD:\n",
+    "    # prepare the apodization window in nD:\n",
     "    import functools\n",
     "    window = functools.reduce(np.multiply.outer, window_tuple)\n",
     "    \n",
-    "    # Apodise:\n",
-    "    image_padded_apodised = window*image_padded\n",
+    "    # Apodize:\n",
+    "    image_padded_apodized = window*image_padded\n",
     "\n",
     "    # Compute the Fourier transform of the image:\n",
-    "    image_fft = np.fft.fftn(image_padded_apodised)\n",
+    "    image_fft = np.fft.fftn(image_padded_apodized)\n",
     "    \n",
     "    # Shift the zero-frequency component to the center of the spectrum:\n",
     "    image_fft_shifted = np.fft.fftshift(image_fft)\n",
@@ -45,14 +45,14 @@
     "    return(magnitude_spectrum)"
    ],
    "outputs": [],
-   "execution_count": 82
+   "execution_count": 87
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-13T14:51:53.594585Z",
-     "start_time": "2024-08-13T14:51:53.590091Z"
+     "end_time": "2024-08-13T14:54:51.702025Z",
+     "start_time": "2024-08-13T14:54:51.695371Z"
     }
    },
    "source": [
@@ -60,7 +60,7 @@
     "    \n",
     "    def fft_spectrum_reference(nd_image, padding):\n",
     "        \"\"\"\n",
-    "        Returns the FFT spectrum of an arbitrary nD image as the absolute logarithm (log1p) of the Fourier transform magnitude. Ensures that the DC component is at the center of the image. Uses reflection padding (provided as integer parameter) and Hamming apodisation to reduce artefacts due to discontinuities at the image borders.\n",
+    "        Returns the FFT spectrum of an arbitrary nD image as the absolute logarithm (log1p) of the Fourier transform magnitude. Ensures that the DC component is at the center of the image. Uses reflection padding (provided as integer parameter) and Hamming apodization to reduce artefacts due to discontinuities at the image borders.\n",
     "        \"\"\"\n",
     "        import numpy as np\n",
     "    \n",
@@ -70,19 +70,19 @@
     "        # Padding:\n",
     "        image_padded = np.pad(nd_image, pad_width=pad_width, mode='symmetric')\n",
     "        \n",
-    "        # prepare the apodisation window in 1D:\n",
+    "        # prepare the apodization window in 1D:\n",
     "        from scipy import signal\n",
     "        window_tuple = (signal.windows.hamming(length+2*padding) for length in nd_image.shape)\n",
     "        \n",
-    "        # prepare the apodisation window in nD:\n",
+    "        # prepare the apodization window in nD:\n",
     "        import functools\n",
     "        window = functools.reduce(np.multiply.outer, window_tuple)\n",
     "        \n",
-    "        # Apodise:\n",
-    "        image_padded_apodised = window*image_padded\n",
+    "        # Apodize:\n",
+    "        image_padded_apodized = window*image_padded\n",
     "    \n",
     "        # Compute the Fourier transform of the image:\n",
-    "        image_fft = np.fft.fftn(image_padded_apodised)\n",
+    "        image_fft = np.fft.fftn(image_padded_apodized)\n",
     "        \n",
     "        # Shift the zero-frequency component to the center of the spectrum:\n",
     "        image_fft_shifted = np.fft.fftshift(image_fft)\n",
@@ -109,19 +109,19 @@
     "    assert np.allclose(magnitude_spectrum_candidate, magnitude_spectrum_reference)"
    ],
    "outputs": [],
-   "execution_count": 83
+   "execution_count": 88
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-13T14:51:54.640311Z",
-     "start_time": "2024-08-13T14:51:54.634402Z"
+     "end_time": "2024-08-13T14:54:52.036029Z",
+     "start_time": "2024-08-13T14:54:52.031560Z"
     }
    },
    "source": "check(fft_spectrum)",
    "outputs": [],
-   "execution_count": 84
+   "execution_count": 89
   },
   {
    "metadata": {},

--- a/test_cases/fft_spectrum.ipynb
+++ b/test_cases/fft_spectrum.ipynb
@@ -4,8 +4,8 @@
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-13T06:48:27.495893Z",
-     "start_time": "2024-08-13T06:48:27.490346Z"
+     "end_time": "2024-08-13T14:51:53.135214Z",
+     "start_time": "2024-08-13T14:51:53.130031Z"
     }
    },
    "source": [
@@ -45,18 +45,53 @@
     "    return(magnitude_spectrum)"
    ],
    "outputs": [],
-   "execution_count": 77
+   "execution_count": 82
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-13T06:48:28.400202Z",
-     "start_time": "2024-08-13T06:48:28.396661Z"
+     "end_time": "2024-08-13T14:51:53.594585Z",
+     "start_time": "2024-08-13T14:51:53.590091Z"
     }
    },
    "source": [
     "def check(candidate):\n",
+    "    \n",
+    "    def fft_spectrum_reference(nd_image, padding):\n",
+    "        \"\"\"\n",
+    "        Returns the FFT spectrum of an arbitrary nD image as the absolute logarithm (log1p) of the Fourier transform magnitude. Ensures that the DC component is at the center of the image. Uses reflection padding (provided as integer parameter) and Hamming apodisation to reduce artefacts due to discontinuities at the image borders.\n",
+    "        \"\"\"\n",
+    "        import numpy as np\n",
+    "    \n",
+    "        # computing padding tuple:\n",
+    "        pad_width = ((padding, padding),)*nd_image.ndim\n",
+    "    \n",
+    "        # Padding:\n",
+    "        image_padded = np.pad(nd_image, pad_width=pad_width, mode='symmetric')\n",
+    "        \n",
+    "        # prepare the apodisation window in 1D:\n",
+    "        from scipy import signal\n",
+    "        window_tuple = (signal.windows.hamming(length+2*padding) for length in nd_image.shape)\n",
+    "        \n",
+    "        # prepare the apodisation window in nD:\n",
+    "        import functools\n",
+    "        window = functools.reduce(np.multiply.outer, window_tuple)\n",
+    "        \n",
+    "        # Apodise:\n",
+    "        image_padded_apodised = window*image_padded\n",
+    "    \n",
+    "        # Compute the Fourier transform of the image:\n",
+    "        image_fft = np.fft.fftn(image_padded_apodised)\n",
+    "        \n",
+    "        # Shift the zero-frequency component to the center of the spectrum:\n",
+    "        image_fft_shifted = np.fft.fftshift(image_fft)\n",
+    "        \n",
+    "        # Compute the magnitude spectrum:\n",
+    "        magnitude_spectrum = np.log1p(np.abs(image_fft_shifted))\n",
+    "            \n",
+    "        return(magnitude_spectrum)\n",
+    "    \n",
     "    import numpy as np   \n",
     "\n",
     "    # Test image:\n",
@@ -69,24 +104,24 @@
     "    magnitude_spectrum_candidate = candidate(image, padding_width)\n",
     "    \n",
     "    # Reference implementation:\n",
-    "    magnitude_spectrum_reference = fft_spectrum(image, padding_width)\n",
+    "    magnitude_spectrum_reference = fft_spectrum_reference(image, padding_width)\n",
     "    \n",
-    "    assert np.array_equal(magnitude_spectrum_candidate, magnitude_spectrum_reference)"
+    "    assert np.allclose(magnitude_spectrum_candidate, magnitude_spectrum_reference)"
    ],
    "outputs": [],
-   "execution_count": 78
+   "execution_count": 83
   },
   {
    "cell_type": "code",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-08-13T06:48:29.827529Z",
-     "start_time": "2024-08-13T06:48:29.821646Z"
+     "end_time": "2024-08-13T14:51:54.640311Z",
+     "start_time": "2024-08-13T14:51:54.634402Z"
     }
    },
    "source": "check(fft_spectrum)",
    "outputs": [],
-   "execution_count": 79
+   "execution_count": 84
   },
   {
    "metadata": {},


### PR DESCRIPTION
This PR contains:
* [ x] a new test-case for the benchmark
  * [ x] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- This test cases require coding a function that returns the FFT spectrum of an nD image with padding and apodisation:

"Returns the FFT spectrum of an arbitrary nD image as the absolute logarithm (log1p) of the Fourier transform magnitude. Ensures that the DC component is at the center of the image. Uses reflection padding (provided as integer parameter) and Hamming apodisation to reduce artefacts due to discontinuities at the image borders"

How do you think will this influence the benchmark results?
- This is a hard one 

Why do you think it makes sense to merge this PR?
- Because of good reasons.



