### PR TITLE
Add test case for translating an image

### DIFF
--- a/test_cases/translate_3d_image_along_vector.ipynb
+++ b/test_cases/translate_3d_image_along_vector.ipynb
@@ -10,17 +10,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 1,
    "id": "399f45c8-a92e-4c95-9a0f-9f2882094a9e",
    "metadata": {},
    "outputs": [],
    "source": [
     "def translate_3d_image_along_vector(image, t_x, t_y, t_z):\n",
     "    '''\n",
-    "    Translate 3d image along arbitrary vector \n",
-    "    translate_x : float, optional, translation along x axis in pixels\n",
-    "    translate_y : float, optional, translation along y axis in pixels\n",
-    "    translate_z : float, optional, translation along z axis in pixels\n",
+    "    Translate a 3d image along a defined vector (in x, y, and z) and return the translated image.\n",
     "    '''\n",
     "    # import statement\n",
     "    from pyclesperanto_prototype import translate\n",
@@ -31,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 2,
    "id": "4e3a4b38-da5d-4904-905c-b1d968c89be7",
    "metadata": {},
    "outputs": [],
@@ -72,10 +69,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 3,
    "id": "db1353be-ede7-498c-9042-0ba70e8f0b15",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\rober\\miniforge3\\envs\\heb\\lib\\site-packages\\pytools\\persistent_dict.py:59: UserWarning: Unable to import recommended hash 'siphash24.siphash13', falling back to 'hashlib.sha256'. Run 'python3 -m pip install siphash24' to install the recommended hash.\n",
+      "  warn(\"Unable to import recommended hash 'siphash24.siphash13', \"\n"
+     ]
+    }
+   ],
    "source": [
     "check(translate_3d_image_along_vector)"
    ]
@@ -105,7 +111,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/test_cases/translate_image.ipynb
+++ b/test_cases/translate_image.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ce132200-ffe5-4dc3-9b46-67774c6a2fc3",
+   "metadata": {},
+   "source": [
+    "# Translate 3D image along a vector "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "399f45c8-a92e-4c95-9a0f-9f2882094a9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def translate_3d_image_along_vector(image, t_x, t_y, t_z):\n",
+    "    '''\n",
+    "    Translate 3d image along arbitrary vector \n",
+    "    translate_x : float, optional, translation along x axis in pixels\n",
+    "    translate_y : float, optional, translation along y axis in pixels\n",
+    "    translate_z : float, optional, translation along z axis in pixels\n",
+    "    '''\n",
+    "    # import statement\n",
+    "    from pyclesperanto_prototype import translate\n",
+    "\n",
+    "    # translate 3d image along t_x, t_y and t_z\n",
+    "    return translate(image, translate_x=t_x, translate_y=t_y, translate_z=t_z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "4e3a4b38-da5d-4904-905c-b1d968c89be7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    # import\n",
+    "    import numpy as np\n",
+    "\n",
+    "    # translation along x, y and z\n",
+    "    t_x = -1\n",
+    "    t_y = 2\n",
+    "    t_z = 1\n",
+    "\n",
+    "    # image\n",
+    "    image = np.array([[[0., 1., 2., 0.],\n",
+    "        [0., 3., 0., 0.],\n",
+    "        [0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.]],\n",
+    "\n",
+    "       [[0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.]]])\n",
+    "\n",
+    "    reference = np.array([[[0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.]],\n",
+    "\n",
+    "       [[0., 0., 0., 0.],\n",
+    "        [0., 0., 0., 0.],\n",
+    "        [1., 2., 0., 0.],\n",
+    "        [3., 0., 0., 0.]]])\n",
+    "\n",
+    "    # assert \n",
+    "    assert np.array_equal(candidate(image, t_x, t_y, t_z), reference)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "db1353be-ede7-498c-9042-0ba70e8f0b15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(translate_3D_image)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25593355-961d-4ba6-9369-6c4c15516dcd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/translate_image.ipynb
+++ b/test_cases/translate_image.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 19,
    "id": "399f45c8-a92e-4c95-9a0f-9f2882094a9e",
    "metadata": {},
    "outputs": [],
@@ -26,12 +26,12 @@
     "    from pyclesperanto_prototype import translate\n",
     "\n",
     "    # translate 3d image along t_x, t_y and t_z\n",
-    "    return translate(image, translate_x=t_x, translate_y=t_y, translate_z=t_z)"
+    "    return translate(image, translate_x = t_x, translate_y = t_y, translate_z = t_z)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "id": "4e3a4b38-da5d-4904-905c-b1d968c89be7",
    "metadata": {},
    "outputs": [],
@@ -72,12 +72,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 21,
    "id": "db1353be-ede7-498c-9042-0ba70e8f0b15",
    "metadata": {},
    "outputs": [],
    "source": [
-    "check(translate_3D_image)"
+    "check(translate_3d_image_along_vector)"
    ]
   },
   {


### PR DESCRIPTION
This PR contains:
* [x] a new test-case for the benchmark
  * [x] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark (but it was used fixing an error (see comment below))
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #7 

Short description:
- adds a test for translating 3d image along vector
- makes use of function `translate` from `pyclesperanto_prototype` (inspired by [this jupyter notebook](https://haesleinhuepf.github.io/BioImageAnalysisNotebooks/19_spatial_transforms/affine_transforms_clesperanto.html)). 
  - input: image and translation in x, y and z
  - output: translated image

How do you think will this influence the benchmark results?
- should be a relatively simple problem

Why do you think it makes sense to merge this PR?
- image translation is frequently used in computer graphics and also has importance in BIA

Comment: Use of LLM for fixing an error
- When writing the translation function, I received an error message in 
`translate_3D_image(image, translate_x, translate_y, translate_z)`
saying
`AttributeError: 'int' object has no attribute 'shape'`
and this specific problem I passed on to ChatGPT based on the GPT-4 architecture, because I was struggling to find my mistake and it turned out to be that I forgot to put `= variable` like this
`translated_image = translate(image, translate_x=translate_x, translate_y=translate_y, translate_z=translate_z)`

Best,
Mara


