### PR TITLE
Update open_image_return_dimensions.ipynb

### DIFF
--- a/test_cases/open_image_return_dimensions.ipynb
+++ b/test_cases/open_image_return_dimensions.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "def open_image_return_dimensions(image_file_location):\n",
     "    \"\"\"\n",
-    "    Opens an image and returns its dimensions\n",
+    "    Opens an image from a path and returns its height and width\n",
     "    \"\"\"\n",
     "    from skimage.io import imread\n",
     "    image = imread(image_file_location)\n",


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 
* [X] test case improvement

Related github issue (if relevant): https://github.com/haesleinhuepf/human-eval-bia/issues/79

Short description:
- Make the order of the height and width return values more explicit.

How do you think will this influence the benchmark results?
- It will make it more likely that [open_image_return_dimensions.](https://github.com/haesleinhuepf/human-eval-bia/blob/main/test_cases/open_image_return_dimensions.ipynb)  will pass

Why do you think it makes sense to merge this PR?
- We will get a more realistic sense of the performance of LLMs regarding this task.