### PR TITLE
bugfix: make evaluation work when called from elsewhere

### DIFF
--- a/human_eval/execution.py
+++ b/human_eval/execution.py
@@ -139,10 +139,11 @@ def swallow_io():
 def create_tempdir(copy_examples: bool = False):
     import os
     import shutil
+    import pathlib
     with tempfile.TemporaryDirectory() as dirname:
         os.mkdir(dirname + "/test")
         if copy_examples:
-            shutil.copytree("../example_data", dirname + "/example_data")
+            shutil.copytree(pathlib.Path(__file__).resolve().parents[0] / "../example_data", dirname + "/example_data")
         with chdir(dirname + "/test"):
             yield dirname
 


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [x] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- This is a bugfix. The evaluation was failing in case example files were used and when the evaluation was called from outside the `/demo/` folder.

How do you think will this influence the benchmark results?
- The current benchmark is not affected. All test-cases / reference code were passing and will be passing.

Why do you think it makes sense to merge this PR?
- This is a step towards making the benchmark callable from anywhere. This is necessary to make it usable in a wider context.



