### PR TITLE
Adjust mean_std_column to accept both pandas and numpy stdev

### DIFF
--- a/test_cases/mean_std_column.ipynb
+++ b/test_cases/mean_std_column.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 2,
    "id": "2243e607-8d2d-4a77-b612-64d8223d70db",
    "metadata": {},
    "outputs": [],
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 3,
    "id": "577fd3b1-aa81-40c0-8a27-88e86ba48718",
    "metadata": {},
    "outputs": [],
@@ -65,9 +65,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:heb]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-heb-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/test_cases/mean_std_column.ipynb
+++ b/test_cases/mean_std_column.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 35,
    "id": "2243e607-8d2d-4a77-b612-64d8223d70db",
    "metadata": {},
    "outputs": [],
@@ -37,46 +37,37 @@
     "    \n",
     "    result_mean, result_std = candidate(df, \"a\")\n",
     "    assert abs(result_mean - 3.938) < 0.001\n",
-    "    assert abs(result_std - 1.170) < 0.001\n",
-    "\n",
+    "    assert ((abs(result_std - 1.170) < 0.001) or (abs(result_std- 1.218) < 0.001))\n",
     "\n",
     "    result_mean, result_std = candidate(df, \"b\")\n",
     "    assert abs(result_mean - 0.415) < 0.001\n",
-    "    assert abs(result_std - 0.151) < 0.001\n",
+    "    assert ((abs(result_std - 0.151) < 0.001) or (abs(result_std- 0.157) < 0.001))\n",
     "\n",
     "    result_mean, result_std = candidate(df, \"c\")\n",
     "    assert abs(result_mean - 3.931) < 0.001\n",
-    "    assert abs(result_std - 1.160) < 0.001\n",
+    "    assert ((abs(result_std - 1.160) < 0.001) or (abs(result_std- 1.207) < 0.001))\n",
     "\n",
     "    result_mean, result_std = candidate(df, \"d\")\n",
     "    assert abs(result_mean - 3.946) < 0.001\n",
-    "    assert abs(result_std - 1.168) < 0.001\n"
+    "    assert ((abs(result_std - 1.168) < 0.001) or (abs(result_std- 1.216) < 0.001))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 36,
    "id": "577fd3b1-aa81-40c0-8a27-88e86ba48718",
    "metadata": {},
    "outputs": [],
    "source": [
     "check(mean_std_column)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d470d040-51c2-4b57-a8bd-82565c6e1642",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:heb]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-heb-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [x] bug fixes 

Related github issue (if relevant): closes #124 

Short description:
- Allows both the unbiased and unbiased standard deviation allowance

How do you think will this influence the benchmark results?
- Fixes many missed positive results for test_case 'mean_std_column.ipynb'

Why do you think it makes sense to merge this PR?
- Makes a more accurate benchmark according to the stated goal and prompt.



