### PR TITLE
[Fixing-Test-Cases] Image Dimensions reading

### DIFF
--- a/test_cases/open_image_return_dimensions.ipynb
+++ b/test_cases/open_image_return_dimensions.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "id": "e2c6981f-99ff-4b38-b150-fe03dfdac762",
    "metadata": {},
    "outputs": [],
@@ -26,34 +26,67 @@
     "def check(candidate):\n",
     "    shape = candidate(\"../example_data/blobs.tif\")\n",
     "    \n",
-    "    assert shape[0] == 254\n",
-    "    assert shape[1] == 256\n"
+    "    assert ((shape[0] == 254) & (shape[1] == 256)) or ((shape[1] == 254) & (shape[0] == 256))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "id": "e4789ed1-dc01-46a6-80b2-dd98d8d7b875",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[43mopen_image_return_dimensions\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[6], line 4\u001b[0m, in \u001b[0;36mcheck\u001b[0;34m(candidate)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcheck\u001b[39m(candidate):\n\u001b[1;32m      2\u001b[0m     shape \u001b[38;5;241m=\u001b[39m candidate(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m../example_data/blobs.tif\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m ((shape[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m254\u001b[39m) \u001b[38;5;241m&\u001b[39m (shape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m256\u001b[39m))\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
    "source": [
     "check(open_image_return_dimensions)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "4e1f23f7-3894-4446-8606-ba2e0d4ea94d",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(256, 254)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from PIL import Image\n",
+    "def open_image_return_dimensions(image_file_location):\n",
+    "    \"\"\"\n",
+    "    Opens an image and returns its dimensions\n",
+    "    \"\"\"\n",
+    "    with Image.open(image_file_location) as img:\n",
+    "        return img.size\n",
+    "# check(open_image_return_dimensions)\n",
+    "open_image_return_dimensions(\"../example_data/blobs.tif\")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:heb]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-heb-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/test_cases/open_image_return_dimensions.ipynb
+++ b/test_cases/open_image_return_dimensions.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "id": "379be22d-e5f6-41d7-b171-f9f02742fd15",
    "metadata": {},
    "outputs": [],
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "e2c6981f-99ff-4b38-b150-fe03dfdac762",
    "metadata": {},
    "outputs": [],
@@ -31,54 +31,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "id": "e4789ed1-dc01-46a6-80b2-dd98d8d7b875",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mcheck\u001b[49m\u001b[43m(\u001b[49m\u001b[43mopen_image_return_dimensions\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn[6], line 4\u001b[0m, in \u001b[0;36mcheck\u001b[0;34m(candidate)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcheck\u001b[39m(candidate):\n\u001b[1;32m      2\u001b[0m     shape \u001b[38;5;241m=\u001b[39m candidate(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m../example_data/blobs.tif\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m ((shape[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m254\u001b[39m) \u001b[38;5;241m&\u001b[39m (shape[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m256\u001b[39m))\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "check(open_image_return_dimensions)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "4e1f23f7-3894-4446-8606-ba2e0d4ea94d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(256, 254)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from PIL import Image\n",
-    "def open_image_return_dimensions(image_file_location):\n",
-    "    \"\"\"\n",
-    "    Opens an image and returns its dimensions\n",
-    "    \"\"\"\n",
-    "    with Image.open(image_file_location) as img:\n",
-    "        return img.size\n",
-    "# check(open_image_return_dimensions)\n",
-    "open_image_return_dimensions(\"../example_data/blobs.tif\")"
    ]
   }
  ],


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [x] bug fixes 

Related github issue (if relevant): resolves a point in #79, helps address #76 

By the way, I'm opting for lots of small PRs so they can be easier to selectively integrate if needed. Hope this is what works best for everyone's workflow.

Short description:
The natural way that PIL reports image shape/size is in (height, width), but the normal way numpy reports image shape is in (width, height). I think both ways are legitimate. 
- This is related to addressing #76 
- The prompt method in #118 also solves this issue, so either solution would work for this.

How do you think will this influence the benchmark results?
- This PR allows for LLMs to use either PIL or Numpy to solve the problem, as well as presumably other ways of solving the problem. It will increase the # of passing LLMs.

Why do you think it makes sense to merge this PR?
- I think it's better to have the prompts constrain on 'what', and let the LLM figure out 'how'. However, I acknowledge this one conflicts with the prompt re-write in #118 , so if that PR is merged this one can be closed.