### PR TITLE
scale image affine transform test case

### DIFF
--- a/test_cases/scale_image_affine_transform.ipynb
+++ b/test_cases/scale_image_affine_transform.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "def scale_image_affine_transform(image,sx,sy):\n",
     "    \"\"\"\n",
-    "    Compose affine transform to scale an image by scaling factors sx and sy. Returns the scaled image and the affine transform matrix used for scaling. \n",
+    "    Compose affine transform to scale an image by scaling factors sx and sy. Returns the scaled image and the affine transform matrix used for scaling in that order. \n",
     "    The affine transform must be a 3x3 matrix in xy order\n",
     "    \"\"\"\n",
     "    from pyclesperanto_prototype import AffineTransform3D\n",
@@ -59,7 +59,6 @@
     "                                [0., 2., 0., 0.],\n",
     "                                [0., 0., 1., 0.],\n",
     "                                [0., 0., 0., 1.]])\n",
-    "    #print(scaled_image,\"\\n\",transform)\n",
     "    assert np.array_equal(scaled_image,reference)\n",
     "    assert np.array_equal(transform,scale_transform)\n",
     "    "

--- a/test_cases/scale_image_affine_transform.ipynb
+++ b/test_cases/scale_image_affine_transform.ipynb
@@ -66,18 +66,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\rajasekhar.p\\Miniconda3\\envs\\heb\\lib\\site-packages\\pytools\\persistent_dict.py:59: UserWarning: Unable to import recommended hash 'siphash24.siphash13', falling back to 'hashlib.sha256'. Run 'python3 -m pip install siphash24' to install the recommended hash.\n",
-      "  warn(\"Unable to import recommended hash 'siphash24.siphash13', \"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "check(scale_image_affine_transform)"
    ]

--- a/test_cases/scale_image_affine_transform.ipynb
+++ b/test_cases/scale_image_affine_transform.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scale_image_affine_transform(image,sx,sy):\n",
+    "    \"\"\"\n",
+    "    Compose affine transform to scale an image by scaling factors sx and sy. Returns the scaled image and the affine transform matrix used for scaling. \n",
+    "    The affine transform must be a 3x3 matrix in xy order\n",
+    "    \"\"\"\n",
+    "    from pyclesperanto_prototype import AffineTransform3D\n",
+    "    import pyclesperanto_prototype as cle \n",
+    "    import numpy as np\n",
+    "    \n",
+    "    output_img_shape =  (image.shape[0]*sy, image.shape[1]*sx)\n",
+    "\n",
+    "    transform = AffineTransform3D()\n",
+    "    transform.center(image.shape)\n",
+    "    transform.scale(scale_x = sx, scale_y = sy)\n",
+    "    transform.center(output_img_shape,undo=True)\n",
+    "    scaled_image = np.array(cle.affine_transform(image,transform=transform,auto_size=True))\n",
+    "    return scaled_image, transform._matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np \n",
+    "    \n",
+    "    image = np.asarray([\n",
+    "            [0, 0, 0, 0, 0],\n",
+    "            [0, 0, 1, 1, 0],\n",
+    "            [0, 0, 1, 1, 0],\n",
+    "            [0, 0, 0, 0, 0],\n",
+    "            [0, 0, 0, 0, 0],\n",
+    "        ])\n",
+    "    sx = 1\n",
+    "    sy = 2\n",
+    "    scaled_image,transform = candidate(image, sx, sy)\n",
+    "    reference = np.asarray([[0, 0, 0, 0, 0,],\n",
+    "                                [0, 0, 0, 0, 0],\n",
+    "                                [0, 0, 1, 1, 0],\n",
+    "                                [0, 0, 1, 1, 0],\n",
+    "                                [0, 0, 1, 1, 0],\n",
+    "                                [0, 0, 1, 1, 0],\n",
+    "                                [0, 0, 0, 0, 0],\n",
+    "                                [0, 0, 0, 0, 0],\n",
+    "                                [0, 0, 0, 0, 0],\n",
+    "                                [0, 0, 0, 0, 0]])\n",
+    "\n",
+    "    scale_transform = np.asarray([[1., 0., 0., 0.],\n",
+    "                                [0., 2., 0., 0.],\n",
+    "                                [0., 0., 1., 0.],\n",
+    "                                [0., 0., 0., 1.]])\n",
+    "    #print(scaled_image,\"\\n\",transform)\n",
+    "    assert np.array_equal(scaled_image,reference)\n",
+    "    assert np.array_equal(transform,scale_transform)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\rajasekhar.p\\Miniconda3\\envs\\heb\\lib\\site-packages\\pytools\\persistent_dict.py:59: UserWarning: Unable to import recommended hash 'siphash24.siphash13', falling back to 'hashlib.sha256'. Run 'python3 -m pip install siphash24' to install the recommended hash.\n",
+      "  warn(\"Unable to import recommended hash 'siphash24.siphash13', \"\n"
+     ]
+    }
+   ],
+   "source": [
+    "check(scale_image_affine_transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR contains:
* [X] a new test-case for the benchmark
  * [X] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #0

Short description:
- Apply scaling to an image and use affine transforms for this

How do you think will this influence the benchmark results?
- This adds a scaling operation and tests the ability of the LLM to create an affine transform for scaling. Scaling involves a translation from origin as well.

Why do you think it makes sense to merge this PR?
- This will be a new test case not covered by current ones.



