### PR TITLE
add sample inspection GUI

### DIFF
--- a/demo/inspect_samples.ipynb
+++ b/demo/inspect_samples.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cc550e70-608a-47ab-b488-602f424321ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = '../data/samples_deepseek-coder-v2.jsonl_results.jsonl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "48993e46-ba18-4baf-9f2a-905621bbe88c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5974269914ef446798b36fa87696233b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(VBox(children=(Label(value='task_id'), Label(value='Task ID: ../test_cases/apply…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from ipywidgets import Label, Textarea, Button, HBox, VBox, Layout\n",
+    "from IPython.display import display\n",
+    "\n",
+    "# Load the JSONL file\n",
+    "with open(filename, 'r') as file:\n",
+    "    data = [json.loads(line) for line in file]\n",
+    "\n",
+    "# Initialize index\n",
+    "current_index = 0\n",
+    "\n",
+    "# Create GUI components\n",
+    "label_task_id = Label(layout=Layout(width='50%'))\n",
+    "textarea_result = Textarea(layout=Layout(width='100%', height='200px'))\n",
+    "textarea_completion = Textarea(layout=Layout(width='100%', height='400px'))\n",
+    "textarea_full_response = Textarea(layout=Layout(width='100%', height='400px'))\n",
+    "label_index = Label()\n",
+    "\n",
+    "# Create navigation buttons\n",
+    "button_back_10 = Button(description=\"Jump 10 backward\")\n",
+    "button_previous = Button(description=\"Show previous\")\n",
+    "button_next = Button(description=\"Show next\")\n",
+    "button_forward_10 = Button(description=\"Jump 10 forward\")\n",
+    "\n",
+    "# Define a function to update display\n",
+    "def update_display(index):\n",
+    "    label_task_id.value = f\"Task ID: {data[index]['task_id']}\"\n",
+    "    textarea_completion.value = data[index]['completion']\n",
+    "    textarea_result.value = data[index]['result']\n",
+    "    textarea_full_response.value = data[index]['full_response']\n",
+    "    label_index.value = f\"Index: {index+1}/{len(data)}\"\n",
+    "\n",
+    "# Button functions\n",
+    "def go_back_10(_):\n",
+    "    global current_index\n",
+    "    current_index = max(0, current_index - 10)\n",
+    "    update_display(current_index)\n",
+    "\n",
+    "def show_previous(_):\n",
+    "    global current_index\n",
+    "    current_index = max(0, current_index - 1)\n",
+    "    update_display(current_index)\n",
+    "\n",
+    "def show_next(_):\n",
+    "    global current_index\n",
+    "    current_index = min(len(data) - 1, current_index + 1)\n",
+    "    update_display(current_index)\n",
+    "\n",
+    "def go_forward_10(_):\n",
+    "    global current_index\n",
+    "    current_index = min(len(data) - 1, current_index + 10)\n",
+    "    update_display(current_index)\n",
+    "\n",
+    "# Assign functions to button clicks\n",
+    "button_back_10.on_click(go_back_10)\n",
+    "button_previous.on_click(show_previous)\n",
+    "button_next.on_click(show_next)\n",
+    "button_forward_10.on_click(go_forward_10)\n",
+    "\n",
+    "def Lab(caption, widget):\n",
+    "    return VBox([\n",
+    "        Label(caption),\n",
+    "        widget\n",
+    "    ], layout=Layout(width='100%'))\n",
+    "\n",
+    "# Layout of the GUI\n",
+    "panel_layout = VBox([\n",
+    "    HBox([\n",
+    "        Lab(\"task_id\", label_task_id), \n",
+    "        Lab(\"result\", textarea_result)]),\n",
+    "    HBox([\n",
+    "        Lab(\"completion\", textarea_completion), \n",
+    "        Lab(\"full_response\", textarea_full_response)]),\n",
+    "    HBox([label_index, button_back_10, button_previous, button_next, button_forward_10])\n",
+    "])\n",
+    "\n",
+    "# Display the initial content\n",
+    "update_display(current_index)\n",
+    "\n",
+    "# Render the GUI\n",
+    "display(panel_layout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c1208a5-7f20-4f85-be9f-1502060786a4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): Might be helpful for #76 

Short description:
- This adds a GUI to facilitate manual inspection of code samples + results

![image](https://github.com/user-attachments/assets/db570538-4d61-4460-8cc0-fdf3fb33b7e1)


How do you think will this influence the benchmark results?
- Not.

Why do you think it makes sense to merge this PR?
- It makes it easier to debug LLM responses.



