### PR TITLE
[Fixing Test Cases] Allow 0 in label image test cases

### DIFF
--- a/test_cases/map_pixel_count_of_labels.ipynb
+++ b/test_cases/map_pixel_count_of_labels.ipynb
@@ -41,7 +41,15 @@
     "        [0,0,0,1,0],\n",
     "    ])\n",
     "\n",
-    "    assert np.array_equal(reference, result)"
+    "    ref_zeros_are_labels = np.asarray([\n",
+    "        [16,16,16,16,16],\n",
+    "        [3,4,4,16,16],\n",
+    "        [3,4,4,16,16],\n",
+    "        [3,16,16,1,16],\n",
+    "        [16,16,16,1,16],\n",
+    "    ])\n",
+    "\n",
+    "    assert (np.array_equal(reference, result) or np.array_equal(ref_zeros_are_labels, result))"
    ]
   },
   {
@@ -49,25 +57,26 @@
    "execution_count": 3,
    "id": "e4789ed1-dc01-46a6-80b2-dd98d8d7b875",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ian/miniconda3/envs/heb/lib/python3.10/site-packages/pytools/persistent_dict.py:59: UserWarning: Unable to import recommended hash 'siphash24.siphash13', falling back to 'hashlib.sha256'. Run 'python3 -m pip install siphash24' to install the recommended hash.\n",
+      "  warn(\"Unable to import recommended hash 'siphash24.siphash13', \"\n"
+     ]
+    }
+   ],
    "source": [
     "check(map_pixel_count_of_labels)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "69f50302-d69f-4659-9512-4bb86db33cbc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:heb]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-heb-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/test_cases/measure_pixel_count_of_labels.ipynb
+++ b/test_cases/measure_pixel_count_of_labels.ipynb
@@ -33,7 +33,7 @@
     "        [0,3,3,0,0],\n",
     "        [0,0,0,4,0],\n",
     "    ])) \n",
-    "    assert np.array_equal([1,3,2,1], result)"
+    "    assert (np.array_equal([1,3,2,1], result) or np.array_equal([18, 1,3,2,1], result))"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/test_cases/workflow_batch_process_folder_count_labels.ipynb
+++ b/test_cases/workflow_batch_process_folder_count_labels.ipynb
@@ -25,6 +25,7 @@
     "        image = imread(folder_location + filename)\n",
     "\n",
     "        labels = np.unique(image).tolist()\n",
+    "        labels.pop(0)\n",
     "\n",
     "        count = len(labels)\n",
     "\n",
@@ -42,12 +43,12 @@
    "source": [
     "def check(candidate):\n",
     "    counts = candidate(\"../example_data/S-BIAD634/groundtruth/\")\n",
-    "    \n",
-    "    assert (counts[\"Ganglioneuroblastoma_0.tif\"] in [300, 301])\n",
-    "    assert (counts[\"Ganglioneuroblastoma_1.tif\"] in [398, 399])\n",
-    "    assert (counts[\"Ganglioneuroblastoma_2.tif\"] in [368, 369])\n",
-    "    assert (counts[\"Ganglioneuroblastoma_3.tif\"] in [378, 379])\n",
-    "    assert (counts[\"Ganglioneuroblastoma_4.tif\"] in [363, 364])\n",
+    "\n",
+    "    assert counts[\"Ganglioneuroblastoma_0.tif\"] == 300\n",
+    "    assert counts[\"Ganglioneuroblastoma_1.tif\"] == 398\n",
+    "    assert counts[\"Ganglioneuroblastoma_2.tif\"] == 368\n",
+    "    assert counts[\"Ganglioneuroblastoma_3.tif\"] == 378\n",
+    "    assert counts[\"Ganglioneuroblastoma_4.tif\"] == 363\n",
     "    assert len(counts.keys()) == 5"
    ]
   },
@@ -64,6 +65,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b38939da-37b8-4572-8227-b35354f3d60d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4e1f23f7-3894-4446-8606-ba2e0d4ea94d",
    "metadata": {},
    "outputs": [],
@@ -72,9 +81,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:heb]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-heb-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/test_cases/workflow_batch_process_folder_count_labels.ipynb
+++ b/test_cases/workflow_batch_process_folder_count_labels.ipynb
@@ -25,7 +25,6 @@
     "        image = imread(folder_location + filename)\n",
     "\n",
     "        labels = np.unique(image).tolist()\n",
-    "        labels.pop(0)\n",
     "\n",
     "        count = len(labels)\n",
     "\n",
@@ -43,12 +42,12 @@
    "source": [
     "def check(candidate):\n",
     "    counts = candidate(\"../example_data/S-BIAD634/groundtruth/\")\n",
-    "\n",
-    "    assert counts[\"Ganglioneuroblastoma_0.tif\"] == 300\n",
-    "    assert counts[\"Ganglioneuroblastoma_1.tif\"] == 398\n",
-    "    assert counts[\"Ganglioneuroblastoma_2.tif\"] == 368\n",
-    "    assert counts[\"Ganglioneuroblastoma_3.tif\"] == 378\n",
-    "    assert counts[\"Ganglioneuroblastoma_4.tif\"] == 363\n",
+    "    \n",
+    "    assert (counts[\"Ganglioneuroblastoma_0.tif\"] in [300, 301])\n",
+    "    assert (counts[\"Ganglioneuroblastoma_1.tif\"] in [398, 399])\n",
+    "    assert (counts[\"Ganglioneuroblastoma_2.tif\"] in [368, 369])\n",
+    "    assert (counts[\"Ganglioneuroblastoma_3.tif\"] in [378, 379])\n",
+    "    assert (counts[\"Ganglioneuroblastoma_4.tif\"] in [363, 364])\n",
     "    assert len(counts.keys()) == 5"
    ]
   },
@@ -65,14 +64,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b38939da-37b8-4572-8227-b35354f3d60d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "4e1f23f7-3894-4446-8606-ba2e0d4ea94d",
    "metadata": {},
    "outputs": [],
@@ -81,9 +72,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:heb]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-heb-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR contains:
* [ ] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [x] bug fixes 

Related github issue (if relevant): closes #130

Short description:
- Test cases involving label images will now accept 0 as a valid label if the LLM solution includes it.

How do you think will this influence the benchmark results?
- Broadly increases the scoring for these test_cases (in my view, nearer to expectation)

Why do you think it makes sense to merge this PR?
- This one also depends a little on #118. If our model prompting becomes more specific (e.g., to directly specify that 0 is not a valid label), this PR may be closed.
