### PR TITLE
Correct dysfunctional test cases

### DIFF
--- a/oryx-build-commands.txt
+++ b/oryx-build-commands.txt
@@ -1,0 +1,2 @@
+PlatformWithVersion=Python 
+BuildCommands=conda env create --file environment.yml --prefix ./venv --quiet

--- a/oryx-build-commands.txt
+++ b/oryx-build-commands.txt
@@ -1,2 +1,0 @@
-PlatformWithVersion=Python 
-BuildCommands=conda env create --file environment.yml --prefix ./venv --quiet

--- a/test_cases/image_metadata_reading.ipynb
+++ b/test_cases/image_metadata_reading.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def image_metadata_reading(image):\n",
+    "    \"\"\"\n",
+    "    Read image shape and data type object from a tiff file. \n",
+    "    Write then the results into a dictionary \n",
+    "    \"\"\"\n",
+    "    import imageio.v3 as iio\n",
+    "    props = iio.improps(image)\n",
+    "    meta_dict = { \"Shape\" : f\"{props.shape}\", \"dtype\" : f\"{props.dtype}\"}\n",
+    "    return meta_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "859ceed62dbcbd1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    img_path = \"example_data/noise.tif\"\n",
+    "    meta_dict_result = candidate(img_path)\n",
+    "\n",
+    "    meta_dict_expected = {'Shape': '(20, 10)', 'dtype': 'uint8'}\n",
+    "    \n",
+    "    assert meta_dict_result == meta_dict_expected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "fb8581fe6d7b73e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(image_metadata_reading)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/read_ome_xml_from_ome_tiff.ipynb
+++ b/test_cases/read_ome_xml_from_ome_tiff.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_ome_metadata_from_ome_tiff(img_path):\n",
+    "    \"\"\"\n",
+    "    Read the ome.xml header from an ome.tiff\n",
+    "    \"\"\"\n",
+    "    from ome_types import from_tiff, to_xml\n",
+    "    ome = from_tiff(img_path)\n",
+    "    return to_xml(ome)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47041db4eac2b5dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    img_path = \"example_data/example.ome.tif\"\n",
+    "    ome_string_result = candidate(img_path)\n",
+    "    \n",
+    "    with open(\"example_data/ome_xml_example.xml\", 'r', encoding='utf-8') as file:\n",
+    "        ome_string_expected = file.read()\n",
+    "        \n",
+    "    ome_string_result = ome_string_result.strip()\n",
+    "    ome_string_expected = ome_string_expected.strip() \n",
+    "\n",
+    "    assert ome_string_result == ome_string_expected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38283683630e2522",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(read_ome_metadata_from_ome_tiff)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_cases/tiff_metadata_reading.ipynb
+++ b/test_cases/tiff_metadata_reading.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "def image_metadata_reading(image_filename):\n",
+    "    \"\"\"\n",
+    "    Read image metadata from tiff file and convert it into a dictionary.\n",
+    "    Ensure that the dictionary only contains a single entry \"shape\" with image dimensions as tuple.\n",
+    "    Return the dictionary.\n",
+    "    \"\"\"\n",
+    "    import json\n",
+    "    \n",
+    "    from bioio import BioImage\n",
+    "    import bioio_tifffile\n",
+    "    img = BioImage(image_filename, reader=bioio_tifffile.Reader)\n",
+    "    metadata = json.loads(img.metadata)\n",
+    "    return metadata"
+   ],
+   "id": "initial_id",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "22fa850f66ddba30",
+   "metadata": {},
+   "source": [
+    "def check(candidate):\n",
+    "    result_metadata = candidate(\"example_data/blobs.tif\")    \n",
+    "    expected_metadata = {\"shape\": [254, 256]}\n",
+    "    \n",
+    "    assert result_metadata == expected_metadata"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "d8b1eb3c6d32e7ab",
+   "metadata": {},
+   "source": [
+    "check(image_metadata_reading)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [X] a new test-case for the benchmark
  * [X] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [X] bug fixes 

Related github issue (if relevant): 
closes #144
closes #145
closes #146

Short description:
- Bug fixes of the case-studies:
    - image_metadata_reading.ipynb
       **Action take:** I rephrase the docstring and the assert-statement in a more clear way
    - read_ome_xml_from_ome_tiff.ipynb
      **Action take:** Problem solved by including the xml encoding
    - tiff_metadata_reading.ipynb
      **Action take:** Working for me on Windows with [bioio 1.1.0 ](https://pypi.org/project/bioio/)and [bioiotifffile 1.0.0](https://pypi.org/project/bioio-tifffile/)
   
How do you think will this influence the benchmark results?
- Same reasons of the PR https://github.com/haesleinhuepf/human-eval-bia/pull/142

Why do you think it makes sense to merge this PR?
- It is nice to have some bug-fixes case-studies



