### PR TITLE
add test to write zarr from array

### DIFF
--- a/test_cases/write_zarr.ipynb
+++ b/test_cases/write_zarr.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "379be22d-e5f6-41d7-b171-f9f02742fd15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def save_zarr(zarr_file_location, array):\n",
+    "    \"\"\"\n",
+    "    Save the array in a zarr file\n",
+    "    \"\"\"\n",
+    "    import zarr\n",
+    "    z = zarr.save(zarr_file_location, array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e2c6981f-99ff-4b38-b150-fe03dfdac762",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import shutil\n",
+    "    import zarr\n",
+    "    import numpy as np\n",
+    "\n",
+    "    outfile = \"../example_data/generated.zarr\"\n",
+    "    data = np.random.rand(*(10, 20, 20))\n",
+    "    try:\n",
+    "        _ = candidate(outfile, data)\n",
+    "        data_loaded = zarr.open(outfile, \"r\")\n",
+    "        if isinstance(data_loaded, zarr.core.Array):\n",
+    "            data_loaded = data_loaded\n",
+    "        elif isinstance(data_loaded, zarr.hierarchy.Group):\n",
+    "            data_loaded = data_loaded[list(data_loaded.keys())[0]]\n",
+    "        assert (data == data_loaded).all()\n",
+    "    finally:\n",
+    "        shutil.rmtree(outfile)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e4789ed1-dc01-46a6-80b2-dd98d8d7b875",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(save_zarr)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR contains:
* [x] a new test-case for the benchmark
  * [ ] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark

I remember that I tried the prompt on Llama and GPT-3.5 🙃, so I cannot confirm the "NO LLM-based....". Do you think someone else should rewrite the PR?

Related github issue (if relevant): closes #73 

Short description:
- Can LLM produce a code to write a zarr file.

How do you think will this influence the benchmark results?
- The benchmark result will probably vary a lot in the zarr structure and group names

Why do you think it makes sense to merge this PR?
- Zarr is becoming a popular tool to save dataset and the benchmark should check the ability of LLM to do so. 

This PR could be improved with adding requirement for the zarr file, asking for example for ngff files metadata as discussed in #73 and #98 