### PR TITLE
add blob detection test case

### DIFF
--- a/test_cases/detect_blobs.ipynb
+++ b/test_cases/detect_blobs.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def detect_blobs(image):\n",
+    "    \"\"\"\n",
+    "    Takes an nd-gray image image and returns a list of blob positions\n",
+    "    \"\"\"\n",
+    "\n",
+    "    import numpy as np\n",
+    "    from skimage.feature import blob_log\n",
+    "\n",
+    "    image_normalized = (image - np.amin(image)) / (np.amax(image) - np.amin(image))\n",
+    "\n",
+    "    result = blob_log(image_normalized)\n",
+    "\n",
+    "    positions = result[:, :-1] # last column is the detected radius\n",
+    "\n",
+    "    return positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check(candidate):\n",
+    "    import numpy as np\n",
+    "    from scipy.ndimage import gaussian_filter\n",
+    "\n",
+    "    blob_positions = (32, 32, 32)\n",
+    "    blob_radius = 6\n",
+    "\n",
+    "    image = np.zeros([64, 64, 64])\n",
+    "    image[blob_positions] = 1\n",
+    "    image = gaussian_filter(image, sigma=blob_radius)\n",
+    "\n",
+    "    result = candidate(image)\n",
+    "\n",
+    "    assert len(result) == 1 # one blob detected\n",
+    "    assert len(result[0]) == 3 # blob positions is 3D\n",
+    "    assert np.allclose(result[0], blob_positions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check(detect_blobs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "devbio-napari-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR contains:
* [x] a new test-case for the benchmark
  * [x] I hereby confirm that NO LLM-based technology (such as github copilot) was used while writing this benchmark
* [ ] new dependencies in requirements.txt
  * [ ] The environment.yml file was updated using the command `conda env export > environment.yml`
* [ ] new generator-functions allowing to sample from other LLMs
* [ ] new samples (`sample_....jsonl` files)
* [ ] new benchmarking results (`..._results.jsonl` files)
* [ ] documentation update
* [ ] bug fixes 

Related github issue (if relevant): closes #154 

Short description:
- Check if models can create a code to do a blob (or spots) detection in a grayscale image 

How do you think will this influence the benchmark results?
- I think this should be a simple benchmark for the models to succeed

Why do you think it makes sense to merge this PR?
- I think blob/spot detection are a common task in BIA, for example detecting beads to calibrate a microscope or point-based registration



